### PR TITLE
Major update: API update and Virtualized OTP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,16 @@ add_library(                saferotp_lib   STATIC
         saferotp_lib/saferotp_direntry.c
         saferotp_lib/saferotp_ecc.c
         saferotp_lib/saferotp_rw.c
+        saferotp_lib/saferotp_debug_stub.c
 )
+
+# HACK -- Manually add the include directory for debug_rtt.h
+#         To support saferotp_lib/saferotp_debug_stub.h
+message(STATUS "SaferOTP ... using hack to include debug_rtt.h")
+target_include_directories( saferotp_lib PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../)
+
 # Cannot be INTERFACE ... as cannot then find "pico/stdlib.h"
 target_link_libraries(      saferotp_lib PRIVATE pico_stdlib)
-target_link_libraries(      saferotp_lib PRIVATE rtt_lib)
 
 target_include_directories( saferotp_lib PRIVATE   saferotp_lib)
 target_include_directories( saferotp_lib PRIVATE   saferotp_inc)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A later version will likely include a "before" and "after" sample
 CMake project.
 
 Disclaimer: I am not a CMake expert, and thus there may be "better"
-ways to do this.
+ways to do this. Pull requests (with explanations) are welcome.
 
 <details><summary>Current steps</summary><P/>
 

--- a/README.md
+++ b/README.md
@@ -3,247 +3,74 @@
 
 ## Purpose
 
-The one-time programmable fuses on the Raspberry Pi RP2350 chip
-provides a great deal of flexibility.  The design has some nice
-features, such as built-in multiple ways to store redundant data.
+Three main purposes:
+1. Provide a simple, consistent API for reading and writing ECC
+   protected data to the OTP rows.
+2. Provide a simple, consistent API for reading and writing
+   data in the other supported formats (`BYTE3X`, `RBIT3`, and `RBIT8`).
+3. Provide a simple API for using virtualized OTP (to reduce the
+   costs of testing and developing anything that modifies OTP data).
 
-## Problems
+## Background
 
-These can allow additional errors to sneak through.
+The one-time programmable (OTP) fuses on the Raspberry Pi RP2350 chip
+provide a great deal of flexibility.  However, the existing
+hardware limits error reporting to raising bus faults when asking for
+the reads to be "guarded" reads.  This same restriction applies to
+the memory-mapped OTP areas.
 
-* ECC algorithm in the datasheet was underspecified.
-* Bootrom does not normally report errors when reading ECC data.
-  * When using guarded reads, a bus fault is reported for ECC errors;
-    While important for security-critical boot, to not normally
-    report ECC decoding errors is a poor design choice.  Moreover,
-    there is no well-defined method for handling bus faults caused
-    by a library's code.
-  * Bootrom does not validate that decoded ECC data (if it detected
-    correctable errors) actually re-encodes to the expected raw data.
-    This lets 3-bit and 5-bit errors slip through(!).
-* Memory-mapped OTP regions normally fail to provide any
-  error reporting for invalidly-encoded / corrupt data.
-  * Same problem as above ... the bootrom appears to be calling
-    into the Synopsys IP block, rather than implementing the ECC
-    checks itself.
-  * The memory-mapped regions are thus also likely using the same
-    undocumented Synopsys IP block, and has the same problems as
-    calling into the bootrom functions.
+The problem is that using "guarded" reads causes bus faults on detected
+ECC errors, but using normal reads simply returns corrupted data.
 
-Development for mere mortals can be expensive, as any
-mistake may make the board unusable (one-time programmable).
-Alternatively, development becomes very slow work, as each
-instruction must be carefully tested.
+This makes it difficult to use the ECC capabilities without significant
+coding effort (handling bus faults, adjustments to faulting thread context,
+and restarting execution of the faulting code ... which might not
+even be possible).  It would have been much nicer if the bootrom APIs
+simply returned an error code for detected ECC errors, rather than
+silently returning corrupt data.
 
-Having a set of well-tested higher-level APIs can greatly
-reduce this burden.
+This library provides that set of simpler APIs, and provides a simple,
+consistent API for both reading and writing data in all supportedreporting errors
+as return values, rather than raising bus faults.
 
-## Complexity
+The library then grew to provide similar APIs for the other encoding formats
+used by the bootrom, and to enable "virtualize" OTP when using this library's
+APIs, to reduce the number of boards that need to be thrown away when testing
+and developing features that modify the OTP data.
 
-* There are many ways data could be encoded:
-  * `RAW` ... 24 bits per row, without any redundancy or ECC
-  * `RBIT3` ... Storing the same 24 bits of data on three rows;
-    Reads use per-bit majority voting to determine set bits
-    (2 of 3 majority voting)
-  * `RBIT8` ... Storing the same 24 bits of data on eight rows;
-    Reads use per-bit majority voting to determine set bits
-    (3 of 8 majority voting)
-  * `BYTE3` ... Storing a the same 8 bits in a row three times;
-    Reads use per-bit majority voting to determine set bits
-    (2 of 3 majority voting)
-  * `ECC` ... Storing 16 bits of usable data in a row, with
-    the ability to correct any single-bit error, and detect
-    any two-bit error via six ECC bits.  The final two bits
-    (BRBP) allow a sector with any single bit flipped to still
-    be usable to store an arbitrary value by indicating that
-    all the 22 remaining bits should be inverted prior to
-    performing error correction/detection.
+## Usage
 
-Unfortunately, not only is it non-trivial to use for common tasks,
-the Error Correction that the BIOS applies does not always do
-what is expected.  For example, when an OTP row has ECC encoded
-data, and multiple bits are flipped (e.g., forcing errors in the
-encoded data), the BIOS may improperly return incorrect data.
+### Brute-force
 
-In addition, when reading an OTP row with ECC encoded data, the
-API appears to require reading **_TWO_** rows at a time.  The
-datasheet says it will return 0xFFFFFFFF on a failure.
-Since the API reads two rows at a time, it cannot indicate which
-of the two rows had correct data (if any).  However, it appears
-that the bootrom does NOT even report ECC errors?
+Copy the library files into your project however you like.
+Ensure all the `.c` files are compiled and linked into your
+project.
 
-The only way that **_might_** (untested) get notified of ECC errors
-is by using "guarded" reads.  However, using guarded reads will
-result in a hard fault ... requiring complex error handling
-code, if the caller expects to simply report the error and
-continue execution.
+### CMake based RP2350 projects
 
-As for the bit-by-bit voting ... That's template code that is
-not glamorous, and requires great care to implement correctly.
-Better to have that occur once in a single library, than to have
-many projects each implement and debug their own version.
+As this is the default for SDK projects, I'll try to list the steps.
 
-Without simple, tested helper APIs, many projects may choose to
-ignore the edge cases, or read only one copy ... effectively
-losing all redundancy.
+Disclaimer: I am not a CMake expert, and thus there may be "better"
+ways to do this.  No support is provided.
 
+* This presumes your project root directory contains a `CMakeLists.txt`
+* Copy the library's entire tree / directory structure into a subdirectory.
+  * e.g., I'll presume you added it to a directory called `saferotp`
+  * This directory should be in the same level as your main `CMakeLists.txt`
+* In this library's directory, modify the following files:
+  * `saferotp_lib/saferotp_debug_stub.h`
+    * Define the `PRINT_` macros listed in the comments at the top of the file to use your preferred debug output method.
+    * Alternatively, define the macros as nothing. e.g., `#define PRINT_ERROR(...)`
+  * `CMakeLists.txt`
+    * Modify the few lines grouped around the `HACK` text, to reference any required diretory for your debug macro support
+    * e.g., remove those few lines if the debug macros are defined to nothing.
+* In your project's main `CMakeLists.txt`:
+  * Ensure CMake parses the library's configuration and builds, etc: `add_subdirectory(saferotp)`.
+  * Ensure your binary links to the library: `target_link_libraries(saferotp_lib)`
 
-## API
+### Why not just use the existing APIs?
 
-The API uses source data byte counts for all encodings.
-In other words, the byte count reflects the size of the buffer
-that the API will read from / write to.
-
-This allows simplified use of the API, as the caller may
-use `sizeof(DATA_STRUCTURE)` when writing that data structure.
-
-### Format specifics
-
-* `RAW` -- Caller provides a `uint32_t` for each OTP row.
-  Only the least significant 24 bits of each `uint32_t` will
-  contain data.  This reflects the API defined by the RP2350 hardware.
-* `RBIT3` and `RBIT8` -- Caller provides a `uint32_t` for each
-  set of three (or eight, respectively) rows that store the data.
-  * For reads, the bit-by-bit majority voting is applied prior
-    to returning the data.
-* `BYTE3` -- Caller provides one `uint8_t` for each row.
-  * For reads, the bit-by-bit majority voting is applied prior
-    to returning the data.
-* `ECC` -- Caller provides one `uint16_t` for each row.
-  * Validly encoded ECC data is returned.
-  * Invalid data returns an error result.
-
-### Error handling / reporting details
-
-#### `ECC` data
-
-The OTP is always read as a raw 24-bit value, which is then manually
-decoded into a potential result.  The potential result is then
-re-encoded using the ECC algorithm into a re-encoded result.
-(BRBP may be applied to the re-encoded result to match the raw data).
-
-Excluding the BRBP bits, it is permissible for the re-encoded result
-and the raw data to differ by at most one bit.  Otherwise, the data
-is considered to not be validly encoded ECC data, and an error is
-reported.  This avoids many false-positive decodings where three or
-five bits were flipped in the raw data.
-
-#### `RBIT3` and `RBIT8` data
-
-Both of these use bit-oriented voting, to determine if a bit
-should be set to `1`.  `RBIT3` requires two votes from the the
-bits stored in three rows, while `RBIT8` requires three votes from
-the bits stored in eight rows.
-
-Currently, the behavior for v1.0 of the library is intended to be:
-* Error conditions that cannot modify the resulting data are ignored / hidden.
-* Error conditions that have the potential to affect the resulting data are reported.
-
-The error conditions here refer to failures to read or write an OTP row.
-
-A future version of the library may allow for a behavior which simply
-**_IGNORES_** OTP rows that cannot be read, at least for `RBIT8`.
-The alternative behavior would have no effect on `RBIT3` nor `BYTE3`
-data.
-
-* Generically, reads occur as follows:
-  * Keep count of how many rows failed to be read.
-  * For OTP rows successfully read, each set bit adds a vote for its corresponding bit.
-  * After reading all rows, determine final bit value for each bit:
-    * If (votes >= `REQUIRED_BITS`) then set bit to 1
-    * else if (read failures >= `REQUIRED_BITS`) then ERROR CONDITION
-    * else if (votes >= `REQUIRED_BITS` - read failures) then ERROR CONDITION
-    * else set bit to 0
-
-* Generically, writes occur as follows:
-  * Determine if impossible to safely write the data by reading the old data, and
-    if so, exit before writing any data.
-  * Read/Modify/Write the requested bits into each rows (ignoring failures for now)
-  * Verify the data read back (using the `RBIT3` / `RBIT8` function) matches the requested data
-
-* How to determine it's impossible to write the requested data:
-  * Read the voted-upon value using existing API
-    * Fails on various error conditions that should also prevent writing
-    * Also fail if any bits in result are `1`, but new value has them as `0`
-      This prevents writing rows when the requested value could not be stored.
-    * Write the new value (read/modify/write) to each OTP row
-    * Read back the new voted-upon value using existing API
-    * Fail if the voted-upon value does not match the requested value.
-    * Else, success!
-
-#### `BYTE3` data
-
-`BYTE3` uses bit-oriented voting, similar to `RBIT3`.  However, by only storing one byte
-in each OTP row, the error conditions are much simpler to handle (the OTP row is either
-readable or not ... whereas `RBIT3` and `RBIT8` have to consider some votes being readable
-and some votes being unreadable).
-
-Thus, if the OTP row is unreadable, it reports an error condition.
-Otherwise, the bit-by-bit voting is applied to retrieve a single byte for each OTP row.
-
-## Stretch Goals
-
-* Support for OTP row ranges outside the user data area.
-
-* Virtualized OTP ... 
-  * At any time, switch from interacting with the real OTP
-    to interacting with a virtual copy.
-  * By default, caches existing values from OTP.
-  * Option to load from any other source (e.g., flash, ROM,
-    config file, ...) a program desires.
-  * Option to persist the current (real or) virtualized OTP
-    to any other source (e.g., flash, config file, ...).
-
-* Enforcing permissions for access to OTP registers.
-  * ***Excluding*** OTP access keys (see below)
-  * Unique permissions support for Secure-mode vs. Non-secure-mode
-     * Initial implementation presumes all access is from secure mode
-  * Application of OTP permissions in PAGEn_LOCK0 and PAGEn_LOCK1 OTP rows
-  * Hard-coded write restriction for PAGE0 (per datasheet)
-  * Reading soft-lock registers, at least at initialization
-    * Detecting other writes would require use of the memory
-      protection features of the RP2350 (to virtualize access
-      to the soft-lock registers).
-
-* By default, failing writes to special OTP rows with unsupported functionality
-  * e.g., OTP access keys, bootloader keys, encryption keys, etc.
-
-* OTP Directory Entries
-  * Dynamically locate data stored in OTP
-  * Add new entries to the directory
-  * Increase yield for boards shipped with imperfect OTP ...
-    fewer binned compared to using fixed rows
-  * Directory entry type specifies how the data is encoded
-    into the OTP rows (RAW, BYTE3, RBIT3, RBIT8, ECC, ...)
-
-
-
-## Non-Goals
-
-* Emulation of OTP Access Keys
-  * Emulation of OTP access keys would require use of the memory
-    protection features of the RP2350 (to virtualize access
-    to the OTP Access Key registers).
-  * OTP Access Key rows are currently treated the same
-    as any other row.
-* Having virtualized OTP have any effect on bootloader,
-  boot encryption, etc.
-* Other interactions with the CPU / hardware.
-  * e.g., don't expect debug access to be locked out
-    or require a key specified only in virtualized OTP.
-
-## Debugging
-
-This is a static library, and so gets embedded into other projects.
-However, it has rich debug outputs through macros that can be
-redefined as appropriate for your system... See:
-* `saferotp_lib/saferotp_debug_stub.h`
-* `saferotp_lib/saferotp_debug_stub.c`
-
-
-This has been tested with input and output sent via Segger's RTT,
-sent via TinyUSB serial port, and likely supports other debug output
-modes, by simply defining a few macros at the head of the file.
+See additional details in `docs/PURPOSE.md` and `docs/USAGE.md`.
 
 ## WORK IN PROGRESS
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,23 @@ features, such as built-in multiple ways to store redundant data.
 These can allow additional errors to sneak through.
 
 * ECC algorithm in the datasheet was underspecified.
-* Bootrom does not report errors when reading ECC data.
-* Bootrom does not validate decoded ECC data (if detected
-  a bitflip), if re-encoded with ECC, matches the read data.
-* Memory-mapped OTP regions fail to provide any
+* Bootrom does not normally report errors when reading ECC data.
+  * When using guarded reads, a bus fault is reported for ECC errors;
+    While important for security-critical boot, to not normally
+    report ECC decoding errors is a poor design choice.  Moreover,
+    there is no well-defined method for handling bus faults caused
+    by a library's code.
+  * Bootrom does not validate that decoded ECC data (if it detected
+    correctable errors) actually re-encodes to the expected raw data.
+    This lets 3-bit and 5-bit errors slip through(!).
+* Memory-mapped OTP regions normally fail to provide any
   error reporting for invalidly-encoded / corrupt data.
+  * Same problem as above ... the bootrom appears to be calling
+    into the Synopsys IP block, rather than implementing the ECC
+    checks itself.
+  * The memory-mapped regions are thus also likely using the same
+    undocumented Synopsys IP block, and has the same problems as
+    calling into the bootrom functions.
 
 Development for mere mortals can be expensive, as any
 mistake may make the board unusable (one-time programmable).
@@ -29,17 +41,17 @@ reduce this burden.
 ## Complexity
 
 * There are many ways data could be encoded:
-  * RAW ... 24 bits per row, without any redundancy or ECC
-  * RBIT3 ... Storing the same 24 bits of data on three rows;
+  * `RAW` ... 24 bits per row, without any redundancy or ECC
+  * `RBIT3` ... Storing the same 24 bits of data on three rows;
     Reads use per-bit majority voting to determine set bits
     (2 of 3 majority voting)
-  * RBIT8 ... Storing the same 24 bits of data on eight rows;
+  * `RBIT8` ... Storing the same 24 bits of data on eight rows;
     Reads use per-bit majority voting to determine set bits
     (3 of 8 majority voting)
-  * BYTE3 ... Storing a the same 8 bits in a row three times;
+  * `BYTE3` ... Storing a the same 8 bits in a row three times;
     Reads use per-bit majority voting to determine set bits
     (2 of 3 majority voting)
-  * ECC ... Storing 16 bits of usable data in a row, with
+  * `ECC` ... Storing 16 bits of usable data in a row, with
     the ability to correct any single-bit error, and detect
     any two-bit error via six ECC bits.  The final two bits
     (BRBP) allow a sector with any single bit flipped to still
@@ -57,35 +69,121 @@ In addition, when reading an OTP row with ECC encoded data, the
 API appears to require reading **_TWO_** rows at a time.  The
 datasheet says it will return 0xFFFFFFFF on a failure.
 Since the API reads two rows at a time, it cannot indicate which
-of the two rows had correct data (if any).  Moreover, it appears
-that the bootrom might NOT report ECC errors ... perhaps
-0xFFFFFFFF is only returned on permission errors?
+of the two rows had correct data (if any).  However, it appears
+that the bootrom does NOT even report ECC errors?
+
+The only way that **_might_** (untested) get notified of ECC errors
+is by using "guarded" reads.  However, using guarded reads will
+result in a hard fault ... requiring complex error handling
+code, if the caller expects to simply report the error and
+continue execution.
 
 As for the bit-by-bit voting ... That's template code that is
 not glamorous, and requires great care to implement correctly.
+Better to have that occur once in a single library, than to have
+many projects each implement and debug their own version.
+
 Without simple, tested helper APIs, many projects may choose to
 ignore the edge cases, or read only one copy ... effectively
 losing all redundancy.
 
+
 ## API
 
-Byte-count oriented for all encodings.  
-* RAW reads and write use `uint32_t` for each row, of which
-  only the least significant 24 bits contain data.
-* Reading RBIT3 and RBIT8 are similar, but will read three
-  (or eight) rows for each `uint32_t` and handle both errors
-  and bit-by-bit majority voting.
-* Writing RBIT3 and RBIT8 handle errors and edge cases,
-  such as allowing the overall write to succeed, even when
-  some bits across those rows are faulty (e.g., cannot be
-  set to one but should be, or already set to 1 but need to
-  store zero), so long as rows will decode correctly.
-* Reads and writes of BYTE3 use `uint8_t` for each row,
-  otherwise similarto RBIT3 / RBIT8
-* Reads and writes of ECC data returns `uint16_t` for each row.
+The API uses source data byte counts for all encodings.
+In other words, the byte count reflects the size of the buffer
+that the API will read from / write to.
 
+This allows simplified use of the API, as the caller may
+use `sizeof(DATA_STRUCTURE)` when writing that data structure.
+
+### Format specifics
+
+* `RAW` -- Caller provides a `uint32_t` for each OTP row.
+  Only the least significant 24 bits of each `uint32_t` will
+  contain data.  This reflects the API defined by the RP2350 hardware.
+* `RBIT3` and `RBIT8` -- Caller provides a `uint32_t` for each
+  set of three (or eight, respectively) rows that store the data.
+  * For reads, the bit-by-bit majority voting is applied prior
+    to returning the data.
+* `BYTE3` -- Caller provides one `uint8_t` for each row.
+  * For reads, the bit-by-bit majority voting is applied prior
+    to returning the data.
+* `ECC` -- Caller provides one `uint16_t` for each row.
+  * Validly encoded ECC data is returned.
+  * Invalid data returns an error result.
+
+### Error handling / reporting details
+
+#### `ECC` data
+
+The OTP is always read as a raw 24-bit value, which is then manually
+decoded into a potential result.  The potential result is then
+re-encoded using the ECC algorithm into a re-encoded result.
+(BRBP may be applied to the re-encoded result to match the raw data).
+
+Excluding the BRBP bits, it is permissible for the re-encoded result
+and the raw data to differ by at most one bit.  Otherwise, the data
+is considered to not be validly encoded ECC data, and an error is
+reported.  This avoids many false-positive decodings where three or
+five bits were flipped in the raw data.
+
+#### `RBIT3` and `RBIT8` data
+
+Both of these use bit-oriented voting, to determine if a bit
+should be set to `1`.  `RBIT3` requires two votes from the the
+bits stored in three rows, while `RBIT8` requires three votes from
+the bits stored in eight rows.
+
+Currently, the behavior for v1.0 of the library is intended to be:
+* Error conditions that cannot modify the resulting data are ignored / hidden.
+* Error conditions that have the potential to affect the resulting data are reported.
+
+The error conditions here refer to failures to read or write an OTP row.
+
+A future version of the library may allow for a behavior which simply
+**_IGNORES_** OTP rows that cannot be read, at least for `RBIT8`.
+The alternative behavior would have no effect on `RBIT3` nor `BYTE3`
+data.
+
+* Generically, reads occur as follows:
+  * Keep count of how many rows failed to be read.
+  * For OTP rows successfully read, each set bit adds a vote for its corresponding bit.
+  * After reading all rows, determine final bit value for each bit:
+    * If (votes >= `REQUIRED_BITS`) then set bit to 1
+    * else if (read failures >= `REQUIRED_BITS`) then ERROR CONDITION
+    * else if (votes >= `REQUIRED_BITS` - read failures) then ERROR CONDITION
+    * else set bit to 0
+
+* Generically, writes occur as follows:
+  * Determine if impossible to safely write the data by reading the old data, and
+    if so, exit before writing any data.
+  * Read/Modify/Write the requested bits into each rows (ignoring failures for now)
+  * Verify the data read back (using the `RBIT3` / `RBIT8` function) matches the requested data
+
+* How to determine it's impossible to write the requested data:
+  * Read the voted-upon value using existing API
+    * Fails on various error conditions that should also prevent writing
+    * Also fail if any bits in result are `1`, but new value has them as `0`
+      This prevents writing rows when the requested value could not be stored.
+    * Write the new value (read/modify/write) to each OTP row
+    * Read back the new voted-upon value using existing API
+    * Fail if the voted-upon value does not match the requested value.
+    * Else, success!
+
+#### `BYTE3` data
+
+`BYTE3` uses bit-oriented voting, similar to `RBIT3`.  However, by only storing one byte
+in each OTP row, the error conditions are much simpler to handle (the OTP row is either
+readable or not ... whereas `RBIT3` and `RBIT8` have to consider some votes being readable
+and some votes being unreadable).
+
+Thus, if the OTP row is unreadable, it reports an error condition.
+Otherwise, the bit-by-bit voting is applied to retrieve a single byte for each OTP row.
 
 ## Stretch Goals
+
+* Support for OTP row ranges outside the user data area.
 
 * Virtualized OTP ... 
   * At any time, switch from interacting with the real OTP
@@ -95,6 +193,21 @@ Byte-count oriented for all encodings.
     config file, ...) a program desires.
   * Option to persist the current (real or) virtualized OTP
     to any other source (e.g., flash, config file, ...).
+
+* Enforcing permissions for access to OTP registers.
+  * ***Excluding*** OTP access keys (see below)
+  * Unique permissions support for Secure-mode vs. Non-secure-mode
+     * Initial implementation presumes all access is from secure mode
+  * Application of OTP permissions in PAGEn_LOCK0 and PAGEn_LOCK1 OTP rows
+  * Hard-coded write restriction for PAGE0 (per datasheet)
+  * Reading soft-lock registers, at least at initialization
+    * Detecting other writes would require use of the memory
+      protection features of the RP2350 (to virtualize access
+      to the soft-lock registers).
+
+* By default, failing writes to special OTP rows with unsupported functionality
+  * e.g., OTP access keys, bootloader keys, encryption keys, etc.
+
 * OTP Directory Entries
   * Dynamically locate data stored in OTP
   * Add new entries to the directory
@@ -104,12 +217,42 @@ Byte-count oriented for all encodings.
     into the OTP rows (RAW, BYTE3, RBIT3, RBIT8, ECC, ...)
 
 
+
+## Non-Goals
+
+* Emulation of OTP Access Keys
+  * Emulation of OTP access keys would require use of the memory
+    protection features of the RP2350 (to virtualize access
+    to the OTP Access Key registers).
+  * OTP Access Key rows are currently treated the same
+    as any other row.
+* Having virtualized OTP have any effect on bootloader,
+  boot encryption, etc.
+* Other interactions with the CPU / hardware.
+  * e.g., don't expect debug access to be locked out
+    or require a key specified only in virtualized OTP.
+
 ## Debugging
 
 This is a static library, and so gets embedded into other projects.
 However, it has rich debug outputs through macros that can be
-redefined as appropriate for your system.   Tested with output
-sent to Segger's RTT, sent via TinyUSB serial port, and likely
-easily supporting other debug output modes, by simply defining
-a few macros at the head of the file.
+redefined as appropriate for your system... See:
+* `saferotp_lib/saferotp_debug_stub.h`
+* `saferotp_lib/saferotp_debug_stub.c`
+
+
+This has been tested with input and output sent via Segger's RTT,
+sent via TinyUSB serial port, and likely supports other debug output
+modes, by simply defining a few macros at the head of the file.
+
+## WORK IN PROGRESS
+
+This library doesn't even have a version number yet.
+However, given how many edge cases were uncovered during testing
+of the RP2350 OTP implementation, it seemed this might be useful
+to many other folks working with the RP2350 ... even if not
+feature complete yet.
+
+
+
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Three main purposes:
 
 ## Background
 
+<details><summary>Background</summary><P/>
+
 The one-time programmable (OTP) fuses on the Raspberry Pi RP2350 chip
 provide a great deal of flexibility.  However, the existing
 hardware limits error reporting to raising bus faults when asking for
@@ -30,28 +32,32 @@ simply returned an error code for detected ECC errors, rather than
 silently returning corrupt data.
 
 This library provides that set of simpler APIs, and provides a simple,
-consistent API for both reading and writing data in all supportedreporting errors
-as return values, rather than raising bus faults.
+consistent API for both reading and writing data in all supported
+formats.  The API reports errors as return values, rather than raising
+bus faults, by only reading the OTP rows in `RAW` form, and applying
+the ECC and other checks in software.
 
 The library then grew to provide similar APIs for the other encoding formats
-used by the bootrom, and to enable "virtualize" OTP when using this library's
+used by the bootrom, and to enable "virtualized" OTP when using this library's
 APIs, to reduce the number of boards that need to be thrown away when testing
 and developing features that modify the OTP data.
 
+</details>
+
 ## Usage
-
-### Brute-force
-
-Copy the library files into your project however you like.
-Ensure all the `.c` files are compiled and linked into your
-project.
 
 ### CMake based RP2350 projects
 
 As this is the default for SDK projects, I'll try to list the steps.
 
+A later version will likely include a "before" and "after" sample
+CMake project.
+
 Disclaimer: I am not a CMake expert, and thus there may be "better"
-ways to do this.  No support is provided.
+ways to do this.
+
+<details><summary>Current steps</summary><P/>
+
 
 * This presumes your project root directory contains a `CMakeLists.txt`
 * Copy the library's entire tree / directory structure into a subdirectory.
@@ -67,6 +73,12 @@ ways to do this.  No support is provided.
 * In your project's main `CMakeLists.txt`:
   * Ensure CMake parses the library's configuration and builds, etc: `add_subdirectory(saferotp)`.
   * Ensure your binary links to the library: `target_link_libraries(saferotp_lib)`
+
+### Brute-force
+
+Copy the library files into your project however you like.
+Ensure all the `.c` files are compiled and linked into your
+project.
 
 ### Why not just use the existing APIs?
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,258 @@
+
+# SaferOTP library for RP2350
+
+## Purpose
+
+The one-time programmable fuses on the Raspberry Pi RP2350 chip
+provides a great deal of flexibility.  The design has some nice
+features, such as built-in multiple ways to store redundant data.
+
+## Problems
+
+These can allow additional errors to sneak through.
+
+* ECC algorithm in the datasheet was underspecified.
+* Bootrom does not normally report errors when reading ECC data.
+  * When using guarded reads, a bus fault is reported for ECC errors;
+    While important for security-critical boot, to not normally
+    report ECC decoding errors is a poor design choice.  Moreover,
+    there is no well-defined method for handling bus faults caused
+    by a library's code.
+  * Bootrom does not validate that decoded ECC data (if it detected
+    correctable errors) actually re-encodes to the expected raw data.
+    This lets 3-bit and 5-bit errors slip through(!).
+* Memory-mapped OTP regions normally fail to provide any
+  error reporting for invalidly-encoded / corrupt data.
+  * Same problem as above ... the bootrom appears to be calling
+    into the Synopsys IP block, rather than implementing the ECC
+    checks itself.
+  * The memory-mapped regions are thus also likely using the same
+    undocumented Synopsys IP block, and has the same problems as
+    calling into the bootrom functions.
+
+Development for mere mortals can be expensive, as any
+mistake may make the board unusable (one-time programmable).
+Alternatively, development becomes very slow work, as each
+instruction must be carefully tested.
+
+Having a set of well-tested higher-level APIs can greatly
+reduce this burden.
+
+## Complexity
+
+* There are many ways data could be encoded:
+  * `RAW` ... 24 bits per row, without any redundancy or ECC
+  * `RBIT3` ... Storing the same 24 bits of data on three rows;
+    Reads use per-bit majority voting to determine set bits
+    (2 of 3 majority voting)
+  * `RBIT8` ... Storing the same 24 bits of data on eight rows;
+    Reads use per-bit majority voting to determine set bits
+    (3 of 8 majority voting)
+  * `BYTE3` ... Storing a the same 8 bits in a row three times;
+    Reads use per-bit majority voting to determine set bits
+    (2 of 3 majority voting)
+  * `ECC` ... Storing 16 bits of usable data in a row, with
+    the ability to correct any single-bit error, and detect
+    any two-bit error via six ECC bits.  The final two bits
+    (BRBP) allow a sector with any single bit flipped to still
+    be usable to store an arbitrary value by indicating that
+    all the 22 remaining bits should be inverted prior to
+    performing error correction/detection.
+
+Unfortunately, not only is it non-trivial to use for common tasks,
+the Error Correction that the BIOS applies does not always do
+what is expected.  For example, when an OTP row has ECC encoded
+data, and multiple bits are flipped (e.g., forcing errors in the
+encoded data), the BIOS may improperly return incorrect data.
+
+In addition, when reading an OTP row with ECC encoded data, the
+API appears to require reading **_TWO_** rows at a time.  The
+datasheet says it will return 0xFFFFFFFF on a failure.
+Since the API reads two rows at a time, it cannot indicate which
+of the two rows had correct data (if any).  However, it appears
+that the bootrom does NOT even report ECC errors?
+
+The only way that **_might_** (untested) get notified of ECC errors
+is by using "guarded" reads.  However, using guarded reads will
+result in a hard fault ... requiring complex error handling
+code, if the caller expects to simply report the error and
+continue execution.
+
+As for the bit-by-bit voting ... That's template code that is
+not glamorous, and requires great care to implement correctly.
+Better to have that occur once in a single library, than to have
+many projects each implement and debug their own version.
+
+Without simple, tested helper APIs, many projects may choose to
+ignore the edge cases, or read only one copy ... effectively
+losing all redundancy.
+
+
+## API
+
+The API uses source data byte counts for all encodings.
+In other words, the byte count reflects the size of the buffer
+that the API will read from / write to.
+
+This allows simplified use of the API, as the caller may
+use `sizeof(DATA_STRUCTURE)` when writing that data structure.
+
+### Format specifics
+
+* `RAW` -- Caller provides a `uint32_t` for each OTP row.
+  Only the least significant 24 bits of each `uint32_t` will
+  contain data.  This reflects the API defined by the RP2350 hardware.
+* `RBIT3` and `RBIT8` -- Caller provides a `uint32_t` for each
+  set of three (or eight, respectively) rows that store the data.
+  * For reads, the bit-by-bit majority voting is applied prior
+    to returning the data.
+* `BYTE3` -- Caller provides one `uint8_t` for each row.
+  * For reads, the bit-by-bit majority voting is applied prior
+    to returning the data.
+* `ECC` -- Caller provides one `uint16_t` for each row.
+  * Validly encoded ECC data is returned.
+  * Invalid data returns an error result.
+
+### Error handling / reporting details
+
+#### `ECC` data
+
+The OTP is always read as a raw 24-bit value, which is then manually
+decoded into a potential result.  The potential result is then
+re-encoded using the ECC algorithm into a re-encoded result.
+(BRBP may be applied to the re-encoded result to match the raw data).
+
+Excluding the BRBP bits, it is permissible for the re-encoded result
+and the raw data to differ by at most one bit.  Otherwise, the data
+is considered to not be validly encoded ECC data, and an error is
+reported.  This avoids many false-positive decodings where three or
+five bits were flipped in the raw data.
+
+#### `RBIT3` and `RBIT8` data
+
+Both of these use bit-oriented voting, to determine if a bit
+should be set to `1`.  `RBIT3` requires two votes from the the
+bits stored in three rows, while `RBIT8` requires three votes from
+the bits stored in eight rows.
+
+Currently, the behavior for v1.0 of the library is intended to be:
+* Error conditions that cannot modify the resulting data are ignored / hidden.
+* Error conditions that have the potential to affect the resulting data are reported.
+
+The error conditions here refer to failures to read or write an OTP row.
+
+A future version of the library may allow for a behavior which simply
+**_IGNORES_** OTP rows that cannot be read, at least for `RBIT8`.
+The alternative behavior would have no effect on `RBIT3` nor `BYTE3`
+data.
+
+* Generically, reads occur as follows:
+  * Keep count of how many rows failed to be read.
+  * For OTP rows successfully read, each set bit adds a vote for its corresponding bit.
+  * After reading all rows, determine final bit value for each bit:
+    * If (votes >= `REQUIRED_BITS`) then set bit to 1
+    * else if (read failures >= `REQUIRED_BITS`) then ERROR CONDITION
+    * else if (votes >= `REQUIRED_BITS` - read failures) then ERROR CONDITION
+    * else set bit to 0
+
+* Generically, writes occur as follows:
+  * Determine if impossible to safely write the data by reading the old data, and
+    if so, exit before writing any data.
+  * Read/Modify/Write the requested bits into each rows (ignoring failures for now)
+  * Verify the data read back (using the `RBIT3` / `RBIT8` function) matches the requested data
+
+* How to determine it's impossible to write the requested data:
+  * Read the voted-upon value using existing API
+    * Fails on various error conditions that should also prevent writing
+    * Also fail if any bits in result are `1`, but new value has them as `0`
+      This prevents writing rows when the requested value could not be stored.
+    * Write the new value (read/modify/write) to each OTP row
+    * Read back the new voted-upon value using existing API
+    * Fail if the voted-upon value does not match the requested value.
+    * Else, success!
+
+#### `BYTE3` data
+
+`BYTE3` uses bit-oriented voting, similar to `RBIT3`.  However, by only storing one byte
+in each OTP row, the error conditions are much simpler to handle (the OTP row is either
+readable or not ... whereas `RBIT3` and `RBIT8` have to consider some votes being readable
+and some votes being unreadable).
+
+Thus, if the OTP row is unreadable, it reports an error condition.
+Otherwise, the bit-by-bit voting is applied to retrieve a single byte for each OTP row.
+
+## Stretch Goals
+
+* Support for OTP row ranges outside the user data area.
+
+* Virtualized OTP ... 
+  * At any time, switch from interacting with the real OTP
+    to interacting with a virtual copy.
+  * By default, caches existing values from OTP.
+  * Option to load from any other source (e.g., flash, ROM,
+    config file, ...) a program desires.
+  * Option to persist the current (real or) virtualized OTP
+    to any other source (e.g., flash, config file, ...).
+
+* Enforcing permissions for access to OTP registers.
+  * ***Excluding*** OTP access keys (see below)
+  * Unique permissions support for Secure-mode vs. Non-secure-mode
+     * Initial implementation presumes all access is from secure mode
+  * Application of OTP permissions in PAGEn_LOCK0 and PAGEn_LOCK1 OTP rows
+  * Hard-coded write restriction for PAGE0 (per datasheet)
+  * Reading soft-lock registers, at least at initialization
+    * Detecting other writes would require use of the memory
+      protection features of the RP2350 (to virtualize access
+      to the soft-lock registers).
+
+* By default, failing writes to special OTP rows with unsupported functionality
+  * e.g., OTP access keys, bootloader keys, encryption keys, etc.
+
+* OTP Directory Entries
+  * Dynamically locate data stored in OTP
+  * Add new entries to the directory
+  * Increase yield for boards shipped with imperfect OTP ...
+    fewer binned compared to using fixed rows
+  * Directory entry type specifies how the data is encoded
+    into the OTP rows (RAW, BYTE3, RBIT3, RBIT8, ECC, ...)
+
+
+
+## Non-Goals
+
+* Emulation of OTP Access Keys
+  * Emulation of OTP access keys would require use of the memory
+    protection features of the RP2350 (to virtualize access
+    to the OTP Access Key registers).
+  * OTP Access Key rows are currently treated the same
+    as any other row.
+* Having virtualized OTP have any effect on bootloader,
+  boot encryption, etc.
+* Other interactions with the CPU / hardware.
+  * e.g., don't expect debug access to be locked out
+    or require a key specified only in virtualized OTP.
+
+## Debugging
+
+This is a static library, and so gets embedded into other projects.
+However, it has rich debug outputs through macros that can be
+redefined as appropriate for your system... See:
+* `saferotp_lib/saferotp_debug_stub.h`
+* `saferotp_lib/saferotp_debug_stub.c`
+
+
+This has been tested with input and output sent via Segger's RTT,
+sent via TinyUSB serial port, and likely supports other debug output
+modes, by simply defining a few macros at the head of the file.
+
+## WORK IN PROGRESS
+
+This library doesn't even have a version number yet.
+However, given how many edge cases were uncovered during testing
+of the RP2350 OTP implementation, it seemed this might be useful
+to many other folks working with the RP2350 ... even if not
+feature complete yet.
+
+
+
+

--- a/docs/API.md
+++ b/docs/API.md
@@ -96,23 +96,27 @@ has the correct votes to read correctly.
 
 Writing value `0x57`, where the raw OTP row contains 0x5708A1`:
 
-`0x575757` --> `0b0101'0111'0101'0111'0101'0111` (3x redundancy)
-`0x5708A1` --> `0b0101'0111'0000'1000'1010'0001` (existing OTP row)
-`0x575FF7` --> `0b0101'0111'0101'1111'1111'0111` (OTP stores the logical OR)
+Value | Binary | Note
+-------|--------|----------------
+`0x575757` | `0b0101'0111'0101'0111'0101'0111` | Byte 3x redundancy
+`0x5708A1` | `0b0101'0111'0000'1000'1010'0001` | Existing raw OTP row
+`0x575FF7` | `0b0101'0111'0101'1111'1111'0111` | OTP row after writing (logical `OR`)
 
 When read back, the three votes are:
 
  Bytes | Binary        | Note
 -------|---------------|----------------
-`0x57` | `0b0101'0111` | votes for each bit position
-`0x5F` | `0b0101'1111` | votes for each bit position
-`0xF7` | `0b1111'0111` | votes for each bit position
-`0x57` | `0b0101'0111` | Bit is `1` where 2+ votes
+`0x57` | `0b0101'0111` | First byte
+`0x5F` | `0b0101'1111` | Second byte
+`0xF7` | `0b1111'0111` | Third byte
+-------|---------------|----------------
+`0x57` | `0b0101'0111` | 2-of-3 voting
 
-Thus, because it would read back correctly as `0x57`, the API would succeed.
+Thus, because it would read back correctly as `0x57`, the API would succeed, even though some extra bits would be set.
 
-Best-effort detection of data that makes it impossible to succeed
-occurs prior to writing the OTP row with addition bits set to `1`.
+The API makes a best-effort to detect if the new value is impossible to
+store in the `BYTE3X` format (e.g., a zero bit already has 2+ votes)
+before the OTP row is written.
 
 </details>
 

--- a/docs/PURPOSE.md
+++ b/docs/PURPOSE.md
@@ -3,130 +3,114 @@
 
 ## Purpose
 
-The one-time programmable fuses on the Raspberry Pi RP2350 chip
-provides a great deal of flexibility.  The design has some nice
-features, such as built-in multiple ways to store redundant data.
+Improve the error reporting and error handling options for using
+the one-time programmable fuses on the Raspberry Pi RP2350 chip.
 
-## Problems
+## Genesis
 
-These can allow additional errors to sneak through.
+When testing how the OTP API worked in practice, it was discovered
+that, even when data was encoded with ECC, the bootrom APIs would
+silently report corrupted data, rather than reporting an error when
+reading ECC data with multiple bits flipped.
 
-* ECC algorithm in the datasheet was underspecified.
-* Bootrom does not normally report errors when reading ECC data.
-  * When using guarded reads, a bus fault is reported for ECC errors;
-    While important for security-critical boot, to not normally
-    report ECC decoding errors is a poor design choice.  Moreover,
-    there is no well-defined method for handling bus faults caused
-    by a library's code.
-  * Bootrom does not validate that decoded ECC data (if it detected
-    correctable errors) actually re-encodes to the expected raw data.
-    This lets 3-bit and 5-bit errors slip through(!).
-* Memory-mapped OTP regions normally fail to provide any
-  error reporting for invalidly-encoded / corrupt data.
-  * Same problem as above ... the bootrom appears to be calling
-    into the Synopsys IP block, rather than implementing the ECC
-    checks itself.
-  * The memory-mapped regions are thus also likely using the same
-    undocumented Synopsys IP block, and has the same problems as
-    calling into the bootrom functions.
+This lead down a rabbit hole of understanding the limitations of
+the Synopsys IP block that Raspberry Pi used for the OTP fuses,
+and how to provide an API that avoids suprising behaviors (such
+as the above successful reads of detectably corrupt ECC data).)
 
-Development for mere mortals can be expensive, as any
-mistake may make the board unusable (one-time programmable).
-Alternatively, development becomes very slow work, as each
-instruction must be carefully tested.
+Reads of corrupted ECC-encoded OTP data silently succeeds
+***by design***.  You see, the Synopsys IP block does not
+indicate any error unless using so-called "Guarded Reads".
+When using guarded reads, the hardware will report a bus fault.
 
-Having a set of well-tested higher-level APIs can greatly
-reduce this burden.
+A bus fault is a hard fault, and thus requires a complex
+error handler to be written to detect the cause was an OTP
+ECC decoding error, and then adjust the CPU to resume
+execution ... WAY outside the scope of a hobbyist project.
 
-## Complexity
+What was needed was a way to read `ECC`-encoded OTP data,
+where the API would simply report `false` if the data could
+not be read, or `true` if the data was read successfully.
 
-* There are many ways data could be encoded:
-  * `RAW` ... 24 bits per row, without any redundancy or ECC
-  * `RBIT3` ... Storing the same 24 bits of data on three rows;
-    Reads use per-bit majority voting to determine set bits
-    (2 of 3 majority voting)
-  * `RBIT8` ... Storing the same 24 bits of data on eight rows;
-    Reads use per-bit majority voting to determine set bits
-    (3 of 8 majority voting)
-  * `BYTE3` ... Storing a the same 8 bits in a row three times;
-    Reads use per-bit majority voting to determine set bits
-    (2 of 3 majority voting)
-  * `ECC` ... Storing 16 bits of usable data in a row, with
-    the ability to correct any single-bit error, and detect
-    any two-bit error via six ECC bits.  The final two bits
-    (BRBP) allow a sector with any single bit flipped to still
-    be usable to store an arbitrary value by indicating that
-    all the 22 remaining bits should be inverted prior to
-    performing error correction/detection.
+## Method of Operation
 
-Unfortunately, not only is it non-trivial to use for common tasks,
-the Error Correction that the BIOS applies does not always do
-what is expected.  For example, when an OTP row has ECC encoded
-data, and multiple bits are flipped (e.g., forcing errors in the
-encoded data), the BIOS may improperly return incorrect data.
+### `ECC`-encoded data
 
-In addition, when reading an OTP row with ECC encoded data, the
-API appears to require reading **_TWO_** rows at a time.  The
-datasheet says it will return 0xFFFFFFFF on a failure.
-Since the API reads two rows at a time, it cannot indicate which
-of the two rows had correct data (if any).  However, it appears
-that the bootrom does NOT even report ECC errors?
+Because the bootrom could not report ECC errors without
+raising a bus fault, this library could not rely on the
+hardware ECC implementation to decode the raw data.
 
-The only way that **_might_** (untested) get notified of ECC errors
-is by using "guarded" reads.  However, using guarded reads will
-result in a hard fault ... requiring complex error handling
-code, if the caller expects to simply report the error and
-continue execution.
+Instead, this library performs a four-step process to
+read from each ECC-encoded OTP row:
 
-As for the bit-by-bit voting ... That's template code that is
-not glamorous, and requires great care to implement correctly.
-Better to have that occur once in a single library, than to have
-many projects each implement and debug their own version.
+1. Read the OTP row as a `RAW` (24-bit) value
+2. Decode the `RAW` value into a ***potential*** result
+3. Re-encode the ***potential*** result into ***re-encoded*** raw data
+4. Verify that the ***re-encoded*** raw data is equivalent to the raw data read in the first step.
 
-Without simple, tested helper APIs, many projects may choose to
-ignore the edge cases, or read only one copy ... effectively
-losing all redundancy.
+If any of these steps fail, the library will report an error.
+
+#### Step 1 - Read `RAW` value
+
+This simply translates to the existing API for reading the raw 24-bit value.
+
+#### Step 2 - Decode the `RAW` value into a ***potential*** result
+
+As per the datasheet, the first thing checked in the `RAW` value are
+the `BRBP` bits.  These are the two most significant of the 24-bit
+`RAW` value.  If both set (`0b11`), it indicates that the remaining
+22 bits of data in the OTP row should be inverted before ***any***
+other interpretation of their value.
+
+Of the remaining 22 bits, the ECC decoding algorithm is applied.
+If the most significant ECC bit is 0, but any of the other five ECC bits
+are non-zero, then there was an even number of bits flipped ...
+a detectable (but not correctable) error.
+If the most significant ECC bit is 1, then the remaining five ECC bits
+define which of the 16 bits of user data needs to be flipped to obtain
+the corrected user data.
+
+#### Step 3 - Re-encode the ***potential*** result into a ***re-encoded*** 22-bit raw value
+
+Yes, encoding can only provide 22-bits of data (16-bits of user data + 5 bits ECC + 1 bit even polarity).
+
+#### Step 4 - Verify that the ***re-encoded*** raw data is equivalent to the raw data read in the first step.
+
+Equivalent is defined to exclude the `BRBP` bits, allowing at most
+a single-bit difference between the `RAW` value the a re-encoding
+of the potential result.
+
+If the originally read `RAW` value had the `BRBP` bits set, then the ***re-encoded*** value's low 24 bits are first inverted.
+
+The re-encode value is then XOR'd with the originally-read `RAW` value,
+giving a value where each matching bit is zero, and each differing bit is
+a one.  Counting how many of the least significant 22 bit are set
+indicates the count of bits that were flipped, compared to storing the
+***potential*** result in an OTP row.
+
+Since the ECC algorithm can only correct a single bit error, if this
+indicates that zero or one bits were flipped, then the ***potential***
+result becomes a confirmed (final) result.
+
+Otherwise, either the data was not encoded as ECC data, or too many bits
+were flipped (either way, this is an ERROR).
 
 
-## API
 
-The API uses source data byte counts for all encodings.
-In other words, the byte count reflects the size of the buffer
-that the API will read from / write to.
 
-This allows simplified use of the API, as the caller may
-use `sizeof(DATA_STRUCTURE)` when writing that data structure.
 
-### Format specifics
 
-* `RAW` -- Caller provides a `uint32_t` for each OTP row.
-  Only the least significant 24 bits of each `uint32_t` will
-  contain data.  This reflects the API defined by the RP2350 hardware.
-* `RBIT3` and `RBIT8` -- Caller provides a `uint32_t` for each
-  set of three (or eight, respectively) rows that store the data.
-  * For reads, the bit-by-bit majority voting is applied prior
-    to returning the data.
-* `BYTE3` -- Caller provides one `uint8_t` for each row.
-  * For reads, the bit-by-bit majority voting is applied prior
-    to returning the data.
-* `ECC` -- Caller provides one `uint16_t` for each row.
-  * Validly encoded ECC data is returned.
-  * Invalid data returns an error result.
+
+
+
 
 ### Error handling / reporting details
 
-#### `ECC` data
-
-The OTP is always read as a raw 24-bit value, which is then manually
-decoded into a potential result.  The potential result is then
-re-encoded using the ECC algorithm into a re-encoded result.
-(BRBP may be applied to the re-encoded result to match the raw data).
-
 Excluding the BRBP bits, it is permissible for the re-encoded result
-and the raw data to differ by at most one bit.  Otherwise, the data
+and the raw data to differ by ***at most*** one bit.  Otherwise, the data
 is considered to not be validly encoded ECC data, and an error is
-reported.  This avoids many false-positive decodings where three or
-five bits were flipped in the raw data.
+reported.  This avoids many false-positive decodings where
+three or five bits were flipped in the raw data.
 
 #### `RBIT3` and `RBIT8` data
 
@@ -136,63 +120,42 @@ bits stored in three rows, while `RBIT8` requires three votes from
 the bits stored in eight rows.
 
 Currently, the behavior for v1.0 of the library is intended to be:
-* Error conditions that cannot modify the resulting data are ignored / hidden.
-* Error conditions that have the potential to affect the resulting data are reported.
+* Unreadable OTP rows that cannot modify the resulting data are ignored / hidden.
+* Unreadable OTP rows that have the potential to affect the resulting data result in an error.
 
-The error conditions here refer to failures to read or write an OTP row.
+Generically, reads occur as follows:
+* Keep count of how many rows failed to be read.
+* For OTP rows successfully read, each set bit adds a vote for its corresponding bit.
+* After reading all rows, determine final bit value for each bit:
+  * If (votes >= `REQUIRED_BITS`) then set bit to 1
+  * else if (read failures >= `REQUIRED_BITS`) then ERROR CONDITION
+  * else if (votes >= `REQUIRED_BITS` - read failures) then ERROR CONDITION
+  * else set bit to 0
 
-A future version of the library may allow for a behavior which simply
-**_IGNORES_** OTP rows that cannot be read, at least for `RBIT8`.
-The alternative behavior would have no effect on `RBIT3` nor `BYTE3`
-data.
+Generically, writes occur as follows:
+* Determine if impossible to safely write the data by reading the old data
+  * if so, exit before writing any data.
+* Read/Modify/Write the requested bits into each rows (ignoring failures for now)
+* Verify the data read back (using the `RBIT3` / `RBIT8` read function)
+  matches the request new data value
 
-* Generically, reads occur as follows:
-  * Keep count of how many rows failed to be read.
-  * For OTP rows successfully read, each set bit adds a vote for its corresponding bit.
-  * After reading all rows, determine final bit value for each bit:
-    * If (votes >= `REQUIRED_BITS`) then set bit to 1
-    * else if (read failures >= `REQUIRED_BITS`) then ERROR CONDITION
-    * else if (votes >= `REQUIRED_BITS` - read failures) then ERROR CONDITION
-    * else set bit to 0
-
-* Generically, writes occur as follows:
-  * Determine if impossible to safely write the data by reading the old data, and
-    if so, exit before writing any data.
-  * Read/Modify/Write the requested bits into each rows (ignoring failures for now)
-  * Verify the data read back (using the `RBIT3` / `RBIT8` function) matches the requested data
-
-* How to determine it's impossible to write the requested data:
-  * Read the voted-upon value using existing API
-    * Fails on various error conditions that should also prevent writing
-    * Also fail if any bits in result are `1`, but new value has them as `0`
-      This prevents writing rows when the requested value could not be stored.
-    * Write the new value (read/modify/write) to each OTP row
-    * Read back the new voted-upon value using existing API
-    * Fail if the voted-upon value does not match the requested value.
-    * Else, success!
-
-#### `BYTE3` data
-
-`BYTE3` uses bit-oriented voting, similar to `RBIT3`.  However, by only storing one byte
-in each OTP row, the error conditions are much simpler to handle (the OTP row is either
-readable or not ... whereas `RBIT3` and `RBIT8` have to consider some votes being readable
-and some votes being unreadable).
-
-Thus, if the OTP row is unreadable, it reports an error condition.
-Otherwise, the bit-by-bit voting is applied to retrieve a single byte for each OTP row.
+How to determine it's impossible to write the requested data:
+* Read the voted-upon value using existing API
+  * Fails on various error conditions that should also prevent writing
+* Compare the voted-upon value to the requested new value:
+  * If any bits are zero in the requested new value, but report as one
+    when voted upon, then it's impossible to reduce the number of votes,
+    so this results in an ERROR before any value is written.
 
 ## Stretch Goals
 
-* Support for OTP row ranges outside the user data area.
-
-* Virtualized OTP ... 
-  * At any time, switch from interacting with the real OTP
-    to interacting with a virtual copy.
-  * By default, caches existing values from OTP.
-  * Option to load from any other source (e.g., flash, ROM,
-    config file, ...) a program desires.
-  * Option to persist the current (real or) virtualized OTP
-    to any other source (e.g., flash, config file, ...).
+* OTP Directory Entries
+  * Dynamically locate data stored in OTP
+  * Add new entries to the directory
+  * Increase yield for boards shipped with imperfect OTP ...
+    fewer binned compared to using fixed rows
+  * Directory entry type specifies how the data is encoded
+    into the OTP rows (RAW, BYTE3, RBIT3, RBIT8, ECC, ...)
 
 * Enforcing permissions for access to OTP registers.
   * ***Excluding*** OTP access keys (see below)
@@ -207,16 +170,6 @@ Otherwise, the bit-by-bit voting is applied to retrieve a single byte for each O
 
 * By default, failing writes to special OTP rows with unsupported functionality
   * e.g., OTP access keys, bootloader keys, encryption keys, etc.
-
-* OTP Directory Entries
-  * Dynamically locate data stored in OTP
-  * Add new entries to the directory
-  * Increase yield for boards shipped with imperfect OTP ...
-    fewer binned compared to using fixed rows
-  * Directory entry type specifies how the data is encoded
-    into the OTP rows (RAW, BYTE3, RBIT3, RBIT8, ECC, ...)
-
-
 
 ## Non-Goals
 
@@ -235,15 +188,16 @@ Otherwise, the bit-by-bit voting is applied to retrieve a single byte for each O
 ## Debugging
 
 This is a static library, and so gets embedded into other projects.
-However, it has rich debug outputs through macros that can be
-redefined as appropriate for your system... See:
+However, it uses debug macros that allow integration with existing
+debug output options.  See:
 * `saferotp_lib/saferotp_debug_stub.h`
 * `saferotp_lib/saferotp_debug_stub.c`
 
 
 This has been tested with input and output sent via Segger's RTT,
-sent via TinyUSB serial port, and likely supports other debug output
-modes, by simply defining a few macros at the head of the file.
+with `printf`-style output sent via TinyUSB serial port, and it
+likely supports other debug output modes ... by simply defining
+those few macros (and perhaps a few simple functions).
 
 ## WORK IN PROGRESS
 
@@ -252,7 +206,4 @@ However, given how many edge cases were uncovered during testing
 of the RP2350 OTP implementation, it seemed this might be useful
 to many other folks working with the RP2350 ... even if not
 feature complete yet.
-
-
-
 

--- a/docs/PURPOSE.md
+++ b/docs/PURPOSE.md
@@ -76,32 +76,21 @@ Yes, encoding can only provide 22-bits of data (16-bits of user data + 5 bits EC
 
 #### Step 4 - Verify that the ***re-encoded*** raw data is equivalent to the raw data read in the first step.
 
-Equivalent is defined to exclude the `BRBP` bits, allowing at most
-a single-bit difference between the `RAW` value the a re-encoding
-of the potential result.
+As the re-encoded value does not include `BRBP` bits, equivalent here
+is defined to consider the `RAW` value after it was (possibly)
+inverted because of its own `BRBP` bits.
 
-If the originally read `RAW` value had the `BRBP` bits set, then the ***re-encoded*** value's low 24 bits are first inverted.
-
-The re-encode value is then XOR'd with the originally-read `RAW` value,
-giving a value where each matching bit is zero, and each differing bit is
-a one.  Counting how many of the least significant 22 bit are set
-indicates the count of bits that were flipped, compared to storing the
-***potential*** result in an OTP row.
+The re-encoded value is then XOR'd with the (`BRBP` adjusted) `RAW`
+value.  Counting the number of the low 22 bits are set in the XOR'd
+result indicates how many bits would need to be flipped to get from
+the re-encoded value to what is stored in the OTP row.
 
 Since the ECC algorithm can only correct a single bit error, if this
-indicates that zero or one bits were flipped, then the ***potential***
-result becomes a confirmed (final) result.
+re-encoding indicates that zero or one bits were flipped, then the
+***potential*** result becomes a confirmed (final) result.
 
-Otherwise, either the data was not encoded as ECC data, or too many bits
-were flipped (either way, this is an ERROR).
-
-
-
-
-
-
-
-
+Otherwise, either the data was not encoded as ECC data, or too many
+bits were flipped.  In either case, this is reported as an ERROR.
 
 
 ### Error handling / reporting details

--- a/docs/PURPOSE.md
+++ b/docs/PURPOSE.md
@@ -1,0 +1,258 @@
+
+# SaferOTP library for RP2350
+
+## Purpose
+
+The one-time programmable fuses on the Raspberry Pi RP2350 chip
+provides a great deal of flexibility.  The design has some nice
+features, such as built-in multiple ways to store redundant data.
+
+## Problems
+
+These can allow additional errors to sneak through.
+
+* ECC algorithm in the datasheet was underspecified.
+* Bootrom does not normally report errors when reading ECC data.
+  * When using guarded reads, a bus fault is reported for ECC errors;
+    While important for security-critical boot, to not normally
+    report ECC decoding errors is a poor design choice.  Moreover,
+    there is no well-defined method for handling bus faults caused
+    by a library's code.
+  * Bootrom does not validate that decoded ECC data (if it detected
+    correctable errors) actually re-encodes to the expected raw data.
+    This lets 3-bit and 5-bit errors slip through(!).
+* Memory-mapped OTP regions normally fail to provide any
+  error reporting for invalidly-encoded / corrupt data.
+  * Same problem as above ... the bootrom appears to be calling
+    into the Synopsys IP block, rather than implementing the ECC
+    checks itself.
+  * The memory-mapped regions are thus also likely using the same
+    undocumented Synopsys IP block, and has the same problems as
+    calling into the bootrom functions.
+
+Development for mere mortals can be expensive, as any
+mistake may make the board unusable (one-time programmable).
+Alternatively, development becomes very slow work, as each
+instruction must be carefully tested.
+
+Having a set of well-tested higher-level APIs can greatly
+reduce this burden.
+
+## Complexity
+
+* There are many ways data could be encoded:
+  * `RAW` ... 24 bits per row, without any redundancy or ECC
+  * `RBIT3` ... Storing the same 24 bits of data on three rows;
+    Reads use per-bit majority voting to determine set bits
+    (2 of 3 majority voting)
+  * `RBIT8` ... Storing the same 24 bits of data on eight rows;
+    Reads use per-bit majority voting to determine set bits
+    (3 of 8 majority voting)
+  * `BYTE3` ... Storing a the same 8 bits in a row three times;
+    Reads use per-bit majority voting to determine set bits
+    (2 of 3 majority voting)
+  * `ECC` ... Storing 16 bits of usable data in a row, with
+    the ability to correct any single-bit error, and detect
+    any two-bit error via six ECC bits.  The final two bits
+    (BRBP) allow a sector with any single bit flipped to still
+    be usable to store an arbitrary value by indicating that
+    all the 22 remaining bits should be inverted prior to
+    performing error correction/detection.
+
+Unfortunately, not only is it non-trivial to use for common tasks,
+the Error Correction that the BIOS applies does not always do
+what is expected.  For example, when an OTP row has ECC encoded
+data, and multiple bits are flipped (e.g., forcing errors in the
+encoded data), the BIOS may improperly return incorrect data.
+
+In addition, when reading an OTP row with ECC encoded data, the
+API appears to require reading **_TWO_** rows at a time.  The
+datasheet says it will return 0xFFFFFFFF on a failure.
+Since the API reads two rows at a time, it cannot indicate which
+of the two rows had correct data (if any).  However, it appears
+that the bootrom does NOT even report ECC errors?
+
+The only way that **_might_** (untested) get notified of ECC errors
+is by using "guarded" reads.  However, using guarded reads will
+result in a hard fault ... requiring complex error handling
+code, if the caller expects to simply report the error and
+continue execution.
+
+As for the bit-by-bit voting ... That's template code that is
+not glamorous, and requires great care to implement correctly.
+Better to have that occur once in a single library, than to have
+many projects each implement and debug their own version.
+
+Without simple, tested helper APIs, many projects may choose to
+ignore the edge cases, or read only one copy ... effectively
+losing all redundancy.
+
+
+## API
+
+The API uses source data byte counts for all encodings.
+In other words, the byte count reflects the size of the buffer
+that the API will read from / write to.
+
+This allows simplified use of the API, as the caller may
+use `sizeof(DATA_STRUCTURE)` when writing that data structure.
+
+### Format specifics
+
+* `RAW` -- Caller provides a `uint32_t` for each OTP row.
+  Only the least significant 24 bits of each `uint32_t` will
+  contain data.  This reflects the API defined by the RP2350 hardware.
+* `RBIT3` and `RBIT8` -- Caller provides a `uint32_t` for each
+  set of three (or eight, respectively) rows that store the data.
+  * For reads, the bit-by-bit majority voting is applied prior
+    to returning the data.
+* `BYTE3` -- Caller provides one `uint8_t` for each row.
+  * For reads, the bit-by-bit majority voting is applied prior
+    to returning the data.
+* `ECC` -- Caller provides one `uint16_t` for each row.
+  * Validly encoded ECC data is returned.
+  * Invalid data returns an error result.
+
+### Error handling / reporting details
+
+#### `ECC` data
+
+The OTP is always read as a raw 24-bit value, which is then manually
+decoded into a potential result.  The potential result is then
+re-encoded using the ECC algorithm into a re-encoded result.
+(BRBP may be applied to the re-encoded result to match the raw data).
+
+Excluding the BRBP bits, it is permissible for the re-encoded result
+and the raw data to differ by at most one bit.  Otherwise, the data
+is considered to not be validly encoded ECC data, and an error is
+reported.  This avoids many false-positive decodings where three or
+five bits were flipped in the raw data.
+
+#### `RBIT3` and `RBIT8` data
+
+Both of these use bit-oriented voting, to determine if a bit
+should be set to `1`.  `RBIT3` requires two votes from the the
+bits stored in three rows, while `RBIT8` requires three votes from
+the bits stored in eight rows.
+
+Currently, the behavior for v1.0 of the library is intended to be:
+* Error conditions that cannot modify the resulting data are ignored / hidden.
+* Error conditions that have the potential to affect the resulting data are reported.
+
+The error conditions here refer to failures to read or write an OTP row.
+
+A future version of the library may allow for a behavior which simply
+**_IGNORES_** OTP rows that cannot be read, at least for `RBIT8`.
+The alternative behavior would have no effect on `RBIT3` nor `BYTE3`
+data.
+
+* Generically, reads occur as follows:
+  * Keep count of how many rows failed to be read.
+  * For OTP rows successfully read, each set bit adds a vote for its corresponding bit.
+  * After reading all rows, determine final bit value for each bit:
+    * If (votes >= `REQUIRED_BITS`) then set bit to 1
+    * else if (read failures >= `REQUIRED_BITS`) then ERROR CONDITION
+    * else if (votes >= `REQUIRED_BITS` - read failures) then ERROR CONDITION
+    * else set bit to 0
+
+* Generically, writes occur as follows:
+  * Determine if impossible to safely write the data by reading the old data, and
+    if so, exit before writing any data.
+  * Read/Modify/Write the requested bits into each rows (ignoring failures for now)
+  * Verify the data read back (using the `RBIT3` / `RBIT8` function) matches the requested data
+
+* How to determine it's impossible to write the requested data:
+  * Read the voted-upon value using existing API
+    * Fails on various error conditions that should also prevent writing
+    * Also fail if any bits in result are `1`, but new value has them as `0`
+      This prevents writing rows when the requested value could not be stored.
+    * Write the new value (read/modify/write) to each OTP row
+    * Read back the new voted-upon value using existing API
+    * Fail if the voted-upon value does not match the requested value.
+    * Else, success!
+
+#### `BYTE3` data
+
+`BYTE3` uses bit-oriented voting, similar to `RBIT3`.  However, by only storing one byte
+in each OTP row, the error conditions are much simpler to handle (the OTP row is either
+readable or not ... whereas `RBIT3` and `RBIT8` have to consider some votes being readable
+and some votes being unreadable).
+
+Thus, if the OTP row is unreadable, it reports an error condition.
+Otherwise, the bit-by-bit voting is applied to retrieve a single byte for each OTP row.
+
+## Stretch Goals
+
+* Support for OTP row ranges outside the user data area.
+
+* Virtualized OTP ... 
+  * At any time, switch from interacting with the real OTP
+    to interacting with a virtual copy.
+  * By default, caches existing values from OTP.
+  * Option to load from any other source (e.g., flash, ROM,
+    config file, ...) a program desires.
+  * Option to persist the current (real or) virtualized OTP
+    to any other source (e.g., flash, config file, ...).
+
+* Enforcing permissions for access to OTP registers.
+  * ***Excluding*** OTP access keys (see below)
+  * Unique permissions support for Secure-mode vs. Non-secure-mode
+     * Initial implementation presumes all access is from secure mode
+  * Application of OTP permissions in PAGEn_LOCK0 and PAGEn_LOCK1 OTP rows
+  * Hard-coded write restriction for PAGE0 (per datasheet)
+  * Reading soft-lock registers, at least at initialization
+    * Detecting other writes would require use of the memory
+      protection features of the RP2350 (to virtualize access
+      to the soft-lock registers).
+
+* By default, failing writes to special OTP rows with unsupported functionality
+  * e.g., OTP access keys, bootloader keys, encryption keys, etc.
+
+* OTP Directory Entries
+  * Dynamically locate data stored in OTP
+  * Add new entries to the directory
+  * Increase yield for boards shipped with imperfect OTP ...
+    fewer binned compared to using fixed rows
+  * Directory entry type specifies how the data is encoded
+    into the OTP rows (RAW, BYTE3, RBIT3, RBIT8, ECC, ...)
+
+
+
+## Non-Goals
+
+* Emulation of OTP Access Keys
+  * Emulation of OTP access keys would require use of the memory
+    protection features of the RP2350 (to virtualize access
+    to the OTP Access Key registers).
+  * OTP Access Key rows are currently treated the same
+    as any other row.
+* Having virtualized OTP have any effect on bootloader,
+  boot encryption, etc.
+* Other interactions with the CPU / hardware.
+  * e.g., don't expect debug access to be locked out
+    or require a key specified only in virtualized OTP.
+
+## Debugging
+
+This is a static library, and so gets embedded into other projects.
+However, it has rich debug outputs through macros that can be
+redefined as appropriate for your system... See:
+* `saferotp_lib/saferotp_debug_stub.h`
+* `saferotp_lib/saferotp_debug_stub.c`
+
+
+This has been tested with input and output sent via Segger's RTT,
+sent via TinyUSB serial port, and likely supports other debug output
+modes, by simply defining a few macros at the head of the file.
+
+## WORK IN PROGRESS
+
+This library doesn't even have a version number yet.
+However, given how many edge cases were uncovered during testing
+of the RP2350 OTP implementation, it seemed this might be useful
+to many other folks working with the RP2350 ... even if not
+feature complete yet.
+
+
+
+

--- a/saferotp_inc/saferotp.h
+++ b/saferotp_inc/saferotp.h
@@ -1,84 +1,51 @@
 #pragma once
+
+#ifndef SAFEROTP_H
+#define SAFEROTP_H
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <assert.h>
 
-// BUGBUG / TODO - Change prefix from `bp_otp_` or `BP_OTP_` to `saferotp_` or `SAFEROTP_`
-//                 to help avoid conflicts with other libraries.
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+// TODO: CMakefile declaring option to enable/disable OTP virtualization
+//       because this overly-simple method currently uses ~16k of RAM.
 
-#pragma region    // BP_OTP_DIRENTRY_TYPE
-// TODO: REQUIRES --std:c23 or --std:gcc23 -- Fix these to be constexpr instead of macros  
-// TODO: REQUIRES --std:c23 or --std:gcc23 -- Fix initialization to use above constexpr structs
-
-// Must be defined at same level as OTP directory item API,
-// to allow defining the OTPDIR_ENTRY_TYPE constants.
-typedef enum _SAFEROTP_OTPDIR_DATA_ENCODING_TYPE {
-    // No data is associated with this row.
-    //  Single row, 24-bits of raw data, no error correction or detection
-    SAFEROTP_OTPDIR_DATA_ENCODING_TYPE_NONE                    = 0x0u,
-    // Single row, 24-bits of raw data, no error correction or detection
-    SAFEROTP_OTPDIR_DATA_ENCODING_TYPE_RAW                     = 0x1u,
-    // Single row, 8-bits of data, stored triple-redundant.
-    // Majority voting (2-of-3) is applied for each bit independently.
-    SAFEROTP_OTPDIR_DATA_ENCODING_TYPE_BYTE3X                  = 0x2u,
-    // Identical data stored in three consecutive OTP rows.
-    // Majority voting (2-of-3) is applied for each bit independently.
-    // APIs should be provided the first (lowest) OTP row number.
-    SAFEROTP_OTPDIR_DATA_ENCODING_TYPE_RBIT3                   = 0x3u,
-    // Identical data stored in eight consecutive OTP rows.
-    // Special voting is applied for each bit independently:
-    // If 3 or more rows have the bit set, then that bit is considered set.
-    // This is used ONLY for the critical boot rows.
-    // APIs should be provided the first (lowest) OTP row number.
-    SAFEROTP_OTPDIR_DATA_ENCODING_TYPE_RBIT8                   = 0x4u,
-    // Single row, 16-bits of data, ECC detects 2-bit errors, corrects 1-bit errors
-    // and BRBP allows writing even where a row has a single bit already set to 1
-    // (even if stored value would normally store zero for that bit).
-    SAFEROTP_OTPDIR_DATA_ENCODING_TYPE_ECC                     = 0x5u,
-    // Identical to SAFEROTP_OTPDIR_DATA_ENCODING_TYPE_ECC, with the added
-    // requirement that the record includes at least one trailing zero byte.
-    // This is useful for ASCII / UTF-8 strings.
-    SAFEROTP_OTPDIR_DATA_ENCODING_TYPE_ECC_ASCII_STRING        = 0x6u,
-    // Value is encoded directly within the directory entry as an (up to) 32-bit value.
-    // The least significant 16 bits are stored within the `start_row` field.
-    // The most significant 16 bits are stored within the `byte_count` field.
-    SAFEROTP_OTPDIR_DATA_ENCODING_TYPE_EMBEDED_IN_DIRENTRY     = 0x7u,
-
-    /* Encoding types 0x8..0xE are reserved for future use */
-
-    // This is an invalid entry / cannot read data for this entry
-    SAFEROTP_OTPDIR_DATA_ENCODING_TYPE_INVALID                 = 0xFu,
-} SAFEROTP_OTPDIR_DATA_ENCODING_TYPE;
-
-typedef struct _SAFEROTP_OTPDIR_ENTRY_TYPE {
-    union {
-        uint16_t as_uint16_t;
-        struct {
-            uint16_t id            : 8; // can be extended to 12-bits if ever exceed 255 types for the given encoding type
-            uint16_t must_be_zero  : 4; // reserved for future use
-            uint16_t encoding_type : 4; // e.g., ECC, ECC_String, BYTE3X, RBIT3, RBIT8, RAW
-        };
-    };
-} SAFEROTP_OTPDIR_ENTRY_TYPE;
-static_assert(sizeof(SAFEROTP_OTPDIR_ENTRY_TYPE) == sizeof(uint16_t));
-
-// Two common entry types are required here ...
-// * one for blank entries (allowing appending of more entries)
-// * one for all-0xFF entries (finalized, non-appendable end of directory)
-// Note that, although the encoding type is shown as separate from the ID,
-// the full 32-bit value is used as a single identifier for the entry.
-#define SAFEROTP_OTPDIR_ENTRY_TYPE_END      ((SAFEROTP_OTPDIR_ENTRY_TYPE){ .id = 0x00u, .encoding_type = SAFEROTP_OTPDIR_DATA_ENCODING_TYPE_NONE                          })
-#define SAFEROTP_OTPDIR_ENTRY_TYPE_INVALID  ((SAFEROTP_OTPDIR_ENTRY_TYPE){ .id = 0xFFu, .encoding_type = SAFEROTP_OTPDIR_DATA_ENCODING_TYPE_INVALID, .must_be_zero = 0xFu })
-
-// C11 and C23 don't seem to enable a way to statically assert SAFEROTP_OTPDIR_ENTRY_TYPE_INVALID.as_uint16 == 0xFFFFu.  Sigh...
-#pragma endregion // BP_OTP_DIRENTRY_TYPE
-
+#pragma region    // OTP Virtualization support
+/// @brief 
+/// Initializes the virtualization layer.
+/// By default (mask of 0u), all current values are read from OTP to initialize the virtualized buffer.
+/// If any of the bits of the `ignored_pages_mask` are set, then those pages of OTP rows will not be
+/// read from OTP, and will be initialized to all-zero values.
+/// This function may only be called once ... after which OTP access via this library will
+/// be entirely virtualized.
+/// @param ignored_pages_mask If a bit is set, then the corresponding page of OTP rows will be
+///        initialized with zero instead of the current values
+/// @return true if the virtualization layer was successfully initialized.
+bool saferotp_virtualization_init_pages(uint64_t ignored_pages_mask);
+/// @brief Provides a way to restore a set of virtualized OTP rows, regardless of current values.
+///        This is intended to be used to allow state to be stored / restored externally, enabling
+///        testing of virtualized OTP across reboots.  Restoration can be done at any time, and
+///        in multiple calls, to align with various storage alignment restrictions.
+/// @param starting_row The first row of the OTP pages to restore with the provided values.
+/// @param buffer A buffer containing a `uint32_t` value for each consecutive OTP row to be restored.
+/// @param buffer_size Count of bytes in the buffer. This must be a multiple of 4 bytes.
+/// @return true if the virtualized OTP rows were successfully restored.
+bool saferotp_virtualization_restore(uint16_t starting_row, const void* buffer, size_t buffer_size);
+/// @brief Provides a way to retrieve a set of virtualized OTP rows, regardless of current values
+///        and permissions.  This is intended to be used to allow state to be stored / restored externally,
+///        enabling testing of virtualized OTP across reboots.  Retrieval can be done at any time, and
+///        in multiple calls, to align with various storage alignment restrictions.
+/// @param starting_row The first row of the OTP pages to retrieve with the provided values.
+/// @param buffer A buffer in which to write a `uint32_t` value for each consecutive OTP row to be retrieved.
+/// @param buffer_size Count of bytes in the buffer. This must be a multiple of 4 bytes.
+/// @return true if the virtualized OTP rows were successfully retrieved.
+bool saferotp_virtualization_save(uint16_t starting_row, void* buffer, size_t buffer_size);
+#pragma endregion // OTP Virtualization support
 #pragma region    // OTP Read / Write functions
 
 // RP2350 OTP can encode data in multiple ways:
@@ -88,57 +55,57 @@ static_assert(sizeof(SAFEROTP_OTPDIR_ENTRY_TYPE) == sizeof(uint16_t));
 // * Using multiple rows for N-of-M voting (e.g., boot critical fields might be recorded in eight rows...)
 // There are many edge cases when reading or writing an OTP row,
 
-// NOT RECOMMENDED DUE TO LIKELIHOOD OF UNDETECTED ERRORS:
-// Writes a single OTP row with 24-bits of data.  No ECC / BRBP is used.
-// Returns false if the data could not be written (e.g., if any bit is
-// already set to 1, and the new value sets that bit to zero).
-bool saferotp_write_single_row_raw(uint16_t row, uint32_t new_value);
-// Reads a single OTP row raw, returning the 24-bits of data without interpretation.
-// Using raw encoding is NOT recommended for general use.  However,
-// reading of an OTP row as RAW can help differentiate between
-// being unable to access the OTP row (e.g., locked) vs. ECC errors
-// making the resulting values undecodable.
-bool saferotp_read_single_row_raw(uint16_t row, uint32_t* out_data);
-
-// Writes a single OTP row with 16-bits of data, protected by ECC.
-// Writes will not fail due to a single bit already being set to one.
-// Returns false if the data could not be written (e.g., if more than
-// one bit was already written to 1).
-bool saferotp_write_single_row_ecc(uint16_t row, uint16_t new_value);
-// Reads a single OTP row, applies bit recovery by polarity,
-// and corrects any single-bit errors using ECC.  Returns the
-// corrected 16-bits of data.
-// Returns false if the data could not be successfully read (e.g.,
-// uncorrectable errors detected, etc.)
-bool saferotp_read_single_row_ecc(uint16_t row, uint16_t* out_data);
-
-// Read raw OTP row data, starting at the specified
-// OTP row and continuing until the buffer is filled.
+// `RAW` - NOT RECOMMENDED DUE TO LIKELIHOOD OF UNDETECTED ERRORS:
+// `RAW` - Writes a single OTP row with 24-bits of data.  No ECC / BRBP is used.
+//         It is up to the caller to define and use some type of error correction / detection.
+// Returns false unless all data is written and verified.
+bool saferotp_write_single_value_raw_unsafe(uint16_t row, uint32_t new_value);
+// `RAW` - NOT RECOMMENDED DUE TO LIKELIHOOD OF UNDETECTED ERRORS:
+// `RAW` - Reads a single OTP row raw, returning the 24-bits of data without interpretation.
+//         It is up to the caller to define and use some type of error correction / detection.
+// Returns false unless all requested data is read.
+bool saferotp_read_single_value_raw_unsafe(uint16_t row, uint32_t* out_data);
+// `RAW` - NOT RECOMMENDED DUE TO LIKELIHOOD OF UNDETECTED ERRORS:
+// `RAW` - Write the supplied buffer to OTP, starting at the specified
+//         OTP row and continuing until the buffer is fully written.
+//         It is up to the caller to define and use some type of error correction / detection.
+// Note: count_of_bytes must be an integral multiple of four.
+// Returns false unless all data is written and verified.
+bool saferotp_write_data_raw_unsafe(uint16_t start_row, const void* data, size_t count_of_bytes);
+// `RAW` - NOT RECOMMENDED DUE TO LIKELIHOOD OF UNDETECTED ERRORS:
+// `RAW` - Read raw OTP row data, starting at the specified
+//         OTP row and continuing until the buffer is filled.
+//         It is up to the caller to define and use some type of error correction / detection.
 // Unlike reading of ECC data, the buffer here must be an integral multiple
 // of four bytes.  This restriction is reasonable because the caller
 // must already handle the 3-bytes-in-4 for the buffers.
-bool saferotp_read_raw_data(uint16_t start_row, void* out_data, size_t count_of_bytes);
-// Write the supplied buffer to OTP, starting at the specified
-// OTP row and continuing until the buffer is fully written.
-// Unlike writing ECC data, the buffer must be an integral multiple
-// of four bytes.  This restriction is reasonable because the caller
-// must already handle the 3-bytes-in-4 for the buffers.
-bool saferotp_write_raw_data(uint16_t start_row, const void* data, size_t count_of_bytes);
+// Returns false unless all requested data is read.
+bool saferotp_read_data_raw_unsafe(uint16_t start_row, void* out_data, size_t count_of_bytes);
 
-
-// Write the supplied buffer to OTP, starting at the specified
+// `ECC` - Writes a single OTP row with 16-bits of data, protected by ECC.
+// Writes will NOT fail due to a single bit error.
+// Returns false unless all data is written and verified.
+bool saferotp_write_single_value_ecc(uint16_t row, uint16_t new_value);
+// `ECC` - Reads a single OTP row, applies bit recovery by polarity,
+// and corrects any single-bit errors using ECC.  Returns the
+// corrected 16-bits of data.
+// Returns false unless all requested data is read.
+bool saferotp_read_single_value_ecc(uint16_t row, uint16_t* out_data);
+// `ECC` - Write the supplied buffer to OTP, starting at the specified
 // OTP row and continuing until the buffer is fully written.
 // Allows writing an odd number of bytes, so caller does not have to
 // do extra work to ensure buffer is always an even number of bytes.
 // In this case, the extra byte written will be zero.
-bool saferotp_write_ecc_data(uint16_t start_row, const void* data, size_t count_of_bytes);
-// Fills the supplied buffer with ECC data, starting at the specified
+// Returns false unless all data is written and verified.
+bool saferotp_write_data_ecc(uint16_t start_row, const void* data, size_t count_of_bytes);
+// `ECC` - Fills the supplied buffer with ECC data, starting at the specified
 // OTP row and continuing until the buffer is filled.
 // Allows reading an odd number of bytes, so caller does not have to
 // do extra work to ensure buffer is always an even number of bytes.
-bool saferotp_read_ecc_data(uint16_t start_row, void* out_data, size_t count_of_bytes);
+// Returns false unless all requested data is read.
+bool saferotp_read_data_ecc(uint16_t start_row, void* out_data, size_t count_of_bytes);
 
-// Writes a single OTP row with 8-bits of data stored with 3x redundancy.
+// `BYTE3X` - Writes a single OTP row with 8-bits of data stored with 3x redundancy.
 // For each bit of the new value that is zero:
 //   the existing OTP row is permitted to have that bit set to one in
 //   at most one of the three locations, without causing a failure.
@@ -146,79 +113,58 @@ bool saferotp_read_ecc_data(uint16_t start_row, void* out_data, size_t count_of_
 // ensure that (with voting applied) the new value was correctly stored.
 // This style of storage is mostly used for flags that are independently
 // updated over multiple OTP writes. 
-bool saferotp_write_single_row_redundant_byte3x(uint16_t row, uint8_t new_value);
-// Reads a single OTP row with 8-bits of data stored with 3x redundancy.
+// Returns false unless all data is written and verified (with voting applied).
+bool saferotp_write_single_value_byte3x(uint16_t row, uint8_t new_value);
+// `BYTE3X` - Reads a single OTP row with 8-bits of data stored with 3x redundancy.
 // Returns the 8-bits of data, after applying 2-of-3 voting.
-bool saferotp_read_single_row_redundant_byte3x(uint16_t row, uint8_t* out_data);
+// Returns false unless all requested data is read.
+bool saferotp_read_single_value_byte3x(uint16_t row, uint8_t* out_data);
 
-// Writes three consecutive rows of OTP data with same 24-bit data.
+// TODO: add `saferotp_write_data_byte3x(uint16_t start_row, const void* data, size_t count_of_bytes);`
+// TODO: add `saferotp_read_data_byte3x(uint16_t start_row, void* out_data, size_t count_of_bytes);`
+
+// `RBIT3` - Writes three consecutive rows of OTP data with same 24-bit data.
 // For each bit with a new value of zero:
 //   the existing OTP rows are permitted to have that bit set to one
 //   in one of the three rows, without this function failing.
 // After writing the new values, the function reads the value back
 // and will return false if the value (with voting applied) is not
 // the expected new value.
-bool saferotp_write_redundant_rows_RBIT3(uint16_t start_row, uint32_t new_value);
-// Writes eight consecutive rows of OTP data with same 24-bit data.
+// Returns false unless all data is written and verified (with voting applied).
+bool saferotp_write_single_value_rbit3(uint16_t start_row, uint32_t new_value);
+// `RBIT3` - Reads three consecutive rows of raw OTP data (24-bits), and applies
+// 2-of-3 voting for each bit independently.
+// So long as at least two reads succeed, the data will be returned.
+// Returns the 24-bits of voted-upon data.
+// Returns false unless all requested data is read.
+bool saferotp_read_single_value_rbit3(uint16_t start_row, uint32_t* out_data);
+
+// TODO: add `saferotp_write_data_rbit3(uint16_t start_row, const void* data, size_t count_of_bytes);`
+// TODO: add `saferotp_read_data_rbit3(uint16_t start_row, void* out_data, size_t count_of_bytes);`
+
+// `RBIT8` - Writes eight consecutive rows of OTP data with same 24-bit data.
 // For each bit with a new value of zero:
 //   the existing OTP rows are permitted to have that bit set to one
 //   in one of the eight rows, without this function failing.
 // After writing the new values, the function reads the value back
 // and will return false if the value (with voting applied) is not
 // the expected new value.
-bool saferotp_write_redundant_rows_RBIT8(uint16_t start_row, uint32_t new_value);
-// Reads three consecutive rows of raw OTP data (24-bits), and applies
-// 2-of-3 voting for each bit independently.
-// So long as at least two reads succeed, the data will be returned.
-// Returns the 24-bits of voted-upon data.
-bool saferotp_read_redundant_rows_RBIT3(uint16_t start_row, uint32_t* out_data);
-// Reads eight consecutive rows of raw OTP data (24-bits), and applies
+// Returns false unless all data is written and verified (with voting applied).
+bool saferotp_write_single_value_rbit8(uint16_t start_row, uint32_t new_value);
+// `RBIT8` - Reads eight consecutive rows of raw OTP data (24-bits), and applies
 // 3-of-8 voting for each bit independently.
 // So long as at least three reads succeed, the data will be returned.
 // Returns the 24-bits of voted-upon data.
-bool saferotp_read_redundant_rows_RBIT8(uint16_t start_row, uint32_t* out_data);
-#pragma endregion // OTP Read / Write functions
-#pragma region    // OTP Directory related functions (layer above the OTP read/write functions)
-// Resets the OTP directory iterator to the first entry.
-// For now, iterator state is kept per-CPU.  May change later to externally-allocated state.
-// Returns FALSE when no more entries will be enumerated. (e.g., no entries found)
-bool saferotp_otpdir_find_first_entry(void);
-// Moves the current iterator to the next entry.
-// Returns FALSE when no more entries will be enumerated. (e.g., no additional entries found)
-bool saferotp_otpdir_find_next_entry(void);
-// Resets the OTP directory iterator, and iterates until finding the specified entry type.
-// Returns FALSE when no more entries will be enumerated. (e.g., no entries found)
-bool saferotp_otpdir_find_first_entry_of_type(SAFEROTP_OTPDIR_ENTRY_TYPE entryType);
-// Moves the current iterator to the next entry of the specified type.
-// Returns FALSE when no more entries will be enumerated. (e.g., no additional entries found)
-bool saferotp_otpdir_find_next_entry_of_type(SAFEROTP_OTPDIR_ENTRY_TYPE entryType);
+// Returns false unless all requested data is read.
+bool saferotp_read_single_value_rbit8(uint16_t start_row, uint32_t* out_data);
 
-// Returns the TYPE of the current entry.
-// If the iterator is at the end, then the type is SAFEROTP_OTPDIR_DATA_ENCODING_TYPE_NONE.
-SAFEROTP_OTPDIR_ENTRY_TYPE saferotp_otpdir_get_current_entry_type(void);
-// Returns the buffer size (in bytes) required to get the data referenced by the current entry.
-// Gives a consistent API for all the various data encoding schemes (RAW, byte3x, RBIT3, RBIT8, etc.)
-// NOTE: This provides a count of bytes required to retrieve the data, abstracting away the various encoding schemes
-//       with their various conversions to/from row counts.   Simplifies things for the caller to only deal with bytes.
-size_t saferotp_otpdir_get_current_entry_buffer_size(void);
-// Reads the data from OTP on behalf of the caller.  If the data is successfully read (and validated,
-// for all types except RAW), the data will be in the caller-supplied buffer.
-// Automatically handles the various data encoding schemes (RAW, byte3x, RBIT3, RBIT8, etc.)
-size_t saferotp_otpdir_get_current_entry_data(void* buffer, size_t buffer_size);
-// Verification includes:
-// * entry type encoding is either ECC or ECC_ASCII_STRING
-// * valid_byte_count is reasonable
-// * all rows would exist within the user data OTP rows
-// * all rows are readable
-// * all rows encode valid ECC-encoded data
-// * For ECC_ASCII_STRING
-//   * First N bytes are all in range 0x20..0x7E
-//   * All remaining bytes are 0x00
-//   * The final byte must be 0x00
-bool saferotp_otpdir_add_entry_for_existing_ecc_data(SAFEROTP_OTPDIR_ENTRY_TYPE entryType, uint16_t start_row, size_t valid_data_byte_count);
-#pragma endregion // OTP Directory related functions
+// TODO: add `saferotp_write_data_rbit8(uint16_t start_row, const void* data, size_t count_of_bytes);`
+// TODO: add `saferotp_read_data_rbit8(uint16_t start_row, void* out_data, size_t count_of_bytes);`
+
+#pragma endregion // OTP Read / Write functions
 
 #ifdef __cplusplus
 }
 #endif
 
+#endif // SAFEROTP_H

--- a/saferotp_inc/saferotp_ecc.h
+++ b/saferotp_inc/saferotp_ecc.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifndef SAFEROTP_ECC_H
+#define SAFEROTP_ECC_H
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -68,3 +71,5 @@ uint32_t saferotp_decode_raw(uint32_t data); // [[unsequenced]]
 #ifdef __cplusplus
 }
 #endif
+
+#endif // defined SAFEROTP_ECC_H

--- a/saferotp_lib/saferotp_debug_stub.c
+++ b/saferotp_lib/saferotp_debug_stub.c
@@ -1,0 +1,28 @@
+#include "saferotp_debug_stub.h"
+
+// This example presumes the use of SEGGER RTT
+// for debugging input.
+
+
+// decide where to single-step through the whitelabel process ...
+// controlled via RTT (no USB connection required)
+void SaferOtp_WaitForKey_impl(void) {
+    // clear any prior keypresses
+    int t;
+    do {
+        t = SEGGER_RTT_GetKey();
+    } while (t >= 0);
+
+    // Get a new keypress
+    (void)SEGGER_RTT_WaitKey();
+
+    // And clear any remaining kepresses (particularly useful for telnet, which does line-by-line input)
+    do {
+        t = SEGGER_RTT_GetKey();
+    } while (t >= 0);
+
+    return;
+}
+
+
+

--- a/saferotp_lib/saferotp_debug_stub.h
+++ b/saferotp_lib/saferotp_debug_stub.h
@@ -1,34 +1,35 @@
 #pragma once
 
-// macros used elsewhere
-#define PRINT_FATAL(...)
-#define PRINT_ERROR(...)
-#define PRINT_WARNING(...)
-#define PRINT_INFO(...)
-#define PRINT_VERBOSE(...)
-#define PRINT_DEBUG(...)
-#define MY_DEBUG_WAIT_FOR_KEY()
-
-#if 0 // non-library debug code ... e.g., using Segger RTT for input / output
-//#include "debug_rtt.h"
+// This header file must define the following macros,
+// which are used by the SaferOTP library:
 //
-// During development, it's REALLY useful to force the code to single-step through this process.
-// To support this, this file has code that uses waits for the RTT terminal to accept input.
-//
-// To use this is a TWO STEP process:
-// 1. In the file to wait, define a unique variable:
-//    static volatile bool g_WaitForKey_uniquifier = false;
-// 2. Define WAIT_FOR_KEY() to something similar to the following:
-//     do {
-//        if (g_WaitForKey_uniquifier) {
-//            MY_DEBUG_WAIT_FOR_KEY();
-//        }
-//     } while (0);
-// 3. Adjust `g_WaitForKey_uniquifier` to wait / not wait
-//    in corresponding code locations.
-//
-// Because OTP fuses can only transition from 0 -> 1, this capability is critical to
-// minimizing the number of RP2350 chips with invalid data during development.
+// void PRINT_FATAL(...);
+// void PRINT_ERROR(...);
+// void PRINT_WARNING(...);
+// void PRINT_INFO(...);
+// void PRINT_VERBOSE(...);
+// void PRINT_DEBUG(...);
+// void MY_DEBUG_WAIT_FOR_KEY(void);
 
-#endif
 
+// The BusPirate project uses RTT for debug input/output.
+// It uses the following header to define these PRINT_* macros.
+// e.g., #define PRINT_FATAL(...)   BP_DEBUG_PRINT(BP_DEBUG_LEVEL_FATAL,   BP_DEBUG_DEFAULT_CATEGORY, __VA_ARGS__)
+#define BP_DEBUG_OVERRIDE_DEFAULT_CATEGORY  BP_DEBUG_CAT_OTP
+
+
+// If you get an error here about not finding the header file,
+// review the notes on the few changes needed to integrate this
+// library into your project.
+// It is NOT required to use RTT. However, it IS required to
+// define the above macros, even if the definition of the macro
+// is empty (disabling the output).
+#include "debug_rtt.h"
+
+// And provide an implementation for the `WAIT_FOR_KEY()`
+// macro that uses RTT to wait for a keypress.
+// It is NOT required to use RTT. However, it IS required to
+// define the above macros, even if the definition of the macro
+// is empty (disabling the wait for keypress).
+#define MY_DEBUG_WAIT_FOR_KEY() SaferOtp_WaitForKey_impl()
+void SaferOtp_WaitForKey_impl(void);

--- a/saferotp_lib/saferotp_rw.c
+++ b/saferotp_lib/saferotp_rw.c
@@ -493,6 +493,9 @@ static bool read_single_otp_value_N_of_M(uint16_t start_row, uint8_t N, uint8_t 
         PRINT_ERROR("OTP_RW Error: Read OTP N-of-M: Unsupported N=%d, M=%d\n", N, M);
         return false;
     }
+
+    // NOTE: could process the read values as they come in, but keeping them in an array
+    //       greatly simplifies debugging (and thus testing and initial development).)
     uint32_t v[MAX_M_VALUE] = {0u};    // zero-initialize the array, sized for maximum supported `M`
     bool     r[MAX_M_VALUE] = {false}; // zero-initialized is false
     uint_fast8_t votes[24]; // one count for each potential bit to be set
@@ -542,11 +545,11 @@ static bool read_single_otp_value_N_of_M(uint16_t start_row, uint8_t N, uint8_t 
     // For each bit voted upon:
     //    If the number of votes is >= M:
     //       Set the bit in the result. (SUCCESS)
-    //       Failed reads are irrelevant to this result.
+    //       Failed reads are irrelevant as they cannot cause a transition back to zero.
     //    Else if the number of failed reads is >= (N - votes):
-    //       Votes say zero, but failed reads could make it 1.  (ERROR)
+    //       Current votes say the value is zero, but failed reads could change that result.  (ERROR)
     //    Else:
-    //       The votes say zero, which is true even if all the failed reads
+    //       The votes say zero, which is true ***even if*** all the failed reads
     //       would have added to the vote. (SUCCESS)
     uint32_t result = 0u;
     for (uint_fast8_t i = 0; i < 24u; ++i) {

--- a/saferotp_lib/saferotp_rw.c
+++ b/saferotp_lib/saferotp_rw.c
@@ -13,6 +13,10 @@
 #include "saferotp_debug_stub.h"
 
 
+// Set this global variable anywhere in the code
+// to immediately wait for keypress prior to writing
+// to the OTP fuses.  This will catch ***ALL*** writes
+// that use this library.
 static volatile bool g_WaitForKey_otp_rw = false;
 #define WAIT_FOR_KEY()                 \
     do {                               \
@@ -21,35 +25,70 @@ static volatile bool g_WaitForKey_otp_rw = false;
         }                              \
     } while (0)
 
+#pragma region    // internal static function prototypes
+static bool is_valid_otp_range_raw(uint16_t starting_row, size_t raw_byte_count);
+static bool hw_write_raw_otp_wrapper(uint16_t starting_row, const void* buffer, size_t buffer_size);
+static bool hw_read_raw_otp_wrapper(uint16_t starting_row, void* buffer, size_t buffer_size);
+static bool virt_initialize(uint64_t ignored_pages_mask);
+static bool virt_override_restore(uint16_t starting_row, const void* buffer, size_t buffer_size);
+static bool virt_override_save(uint16_t starting_row, void* buffer, size_t buffer_size);
+static bool virt_write_raw_otp_wrapper(uint16_t starting_row, const void* buffer, size_t buffer_size);
+static bool virt_read_raw_otp_wrapper(uint16_t starting_row, void* buffer, size_t buffer_size);
+static bool write_raw_wrapper(uint16_t starting_row, const void* buffer, size_t buffer_size);
+static bool read_raw_wrapper(uint16_t starting_row, void* buffer, size_t buffer_size);
+static bool read_single_otp_ecc_row(uint16_t row, uint16_t * data_out);
+static bool write_single_otp_ecc_row(uint16_t row, uint16_t data);
+static bool write_single_otp_raw_row(uint16_t row, uint32_t data);
+static bool read_single_otp_value_N_of_M(uint16_t start_row, uint8_t N, uint8_t M, uint32_t* out_data);
+static bool write_single_otp_value_N_of_M(uint16_t start_row, uint8_t N, uint8_t M, uint32_t new_value);
+static bool read_otp_byte_3x(uint16_t row, uint8_t* out_data);
+static bool write_otp_byte_3x(uint16_t row, uint8_t new_value);
+#pragma endregion // internal static function prototypes
 
 // BUGBUG / TODO: enable "virtual" OTP, by writing to memory buffer instead of OTP fuses,
 //                and tracking the written values in a separate buffer (+bitmask indicating which rows were written).
 //                This will allow testing of the OTP code without actually writing to the OTP fuses.
 #pragma region    // OTP HAL layer ... to allow for virtualized OTP
 
+typedef struct _BP_VIRTUALIZED_OTP_BUFFER {
+    SAFEROTP_RAW_READ_RESULT rows[NUM_OTP_ROWS]; // 0x1000 == 4096 rows, requiring 4 bytes each == 16k statically allocated buffer (!!)
+} BP_VIRTUALIZED_OTP_BUFFER;
+static BP_VIRTUALIZED_OTP_BUFFER g_virtual_otp = { 0 };
+static bool g_virtual_otp_initialized = false;
+
 // returns TRUE on successful write, FALSE on failures
 static bool hw_write_raw_otp_wrapper(uint16_t starting_row, const void* buffer, size_t buffer_size) {
+    // NOTE: rom_func_otp_access() ensures necessary bootrom locks are acquired.
+    //       Memory-mapped regions are *NOT* protected from simultaneous access, and
+    //       the documentation explicitly warns that the (opaque) Synopsys OTP IP block
+    //       requires serializing all access to the OTP.
     otp_cmd_t cmd;
     cmd.flags = starting_row;
     cmd.flags |= OTP_CMD_WRITE_BITS;
+    PRINT_DEBUG("OTP WRITE Debug: about to write OTP starting at row %03x %d bytes (0x%x rows\n", starting_row, buffer_size, (buffer_size/sizeof(uint32_t)));
     WAIT_FOR_KEY();
     int r = rom_func_otp_access((uint8_t*)buffer, buffer_size, cmd);
+    if (r != BOOTROM_OK) {
+        PRINT_ERROR("OTP WRITE Error: Failed to write raw OTP values starting at row %03x (%d bytes / 0x%x rows), error %d (0x%x)\n", starting_row, buffer_size, (buffer_size/sizeof(uint32_t)), r, r);
+    }
     return (BOOTROM_OK == r);
 }
 // returns TRUE on successful read, FALSE on failures
 static bool hw_read_raw_otp_wrapper(uint16_t starting_row, void* buffer, size_t buffer_size) {
+    // TODO: Check BOOTLOCK7 to determine if bootrom will require ownership of BOOTLOCK2 (OTP)
+    //       This would return error BOOTROM_ERROR_LOCK_REQUIRED (-19) if this ever occurs.
     otp_cmd_t cmd;
     cmd.flags = starting_row;
     int r = rom_func_otp_access((uint8_t*)buffer, buffer_size, cmd);
+    PRINT_DEBUG("OTP READ Debug: about to write OTP starting at row %03x %d bytes (0x%x rows\n", starting_row, buffer_size, (buffer_size/sizeof(uint32_t)));
+    if (r != BOOTROM_OK) {
+        PRINT_ERROR("OTP READ Error: Failed to write raw OTP values starting at row %03x (%d bytes / 0x%x rows), error %d (0x%x)\n", starting_row, buffer_size, (buffer_size/sizeof(uint32_t)), r, r);
+    }
     return (BOOTROM_OK == r);
 }
 
-
-//#define BP_USE_VIRTUALIZED_OTP
-#if defined(BP_USE_VIRTUALIZED_OTP)
-
 // Enable "virtualized" OTP ... useful for testing.
-// 8k of OTP is a lot to virtualize... 
+// 16k of OTP is a lot to virtualize... 
 // but RP2350 has 512k, of which >256k is currently free, so go with SIMPLE!
 // * [ ] At initialization:
 //   * [ ] Detect if OTP virtualization file exists on media (and correct size)
@@ -59,7 +98,9 @@ static bool hw_read_raw_otp_wrapper(uint16_t starting_row, void* buffer, size_t 
 // * [ ] All OTP writes get logical-OR'd into that buffer
 // * [ ] At clean shutdown, write the virtualized OTP data to NAND
 //
-// For stretch goal of applying OTP page permissions:
+// STRETCH GOALS:
+// Applying OTP page permissions:
+// * [ ] Use memory protection to prevent access to memory-mapped regions (OTP_DATA_BASE ...)
 // * [ ] Support initially presuming all access is from secure mode
 //   * YAGNI - support for non-secure and bootloader modes ... keep it simple!
 // * [ ] OTP Access Keys == YAGNI
@@ -75,44 +116,195 @@ static bool hw_read_raw_otp_wrapper(uint16_t starting_row, void* buffer, size_t 
 //   * Values: 0x0 == R/W, 0x1 == R/O, 0x3 == NO ACCESS
 //   * All other values == YAGNI
 //
-typedef struct _BP_VIRTUALIZED_OTP_BUFFER {
-    SAFEROTP_RAW_READ_RESULT rows[0x1000]; // 0x1000 == 4096 rows, requiring 4 bytes each in simplest raw form
-} BP_VIRTUALIZED_OTP_BUFFER;
-static BP_VIRTUALIZED_OTP_BUFFER g_virtual_otp = { };
 
-static void initialize_virtualized_otp(void) {
-    // read all 8k of OTP into the virtualized buffer
-    for (uint16_t row = 0; row < 0x1000u; ++row) {
-        int r = read_raw_wrapper(row, &g_virtual_otp.rows[row], sizeof(SAFEROTP_RAW_READ_RESULT));
-        if (BOOTROM_OK != r) {
-            PRINT_ERROR("OTP_RW Error: virtual otp init: Failed to read row %03x: %d (0x%x)\n", row, r, r);
-            g_virtual_otp.rows[row].as_uint32 = 0xFFFFFFFFu; // ensure the stored value is an error
+static_assert(NUM_OTP_ROWS == 0x1000u, "NUM_OTP_ROWS must be 0x1000");
+static_assert(NUM_OTP_ROWS <= UINT16_MAX, "NUM_OTP_ROWS must be less than 0xFFFF ... or else must update range checks for overflow conditions");
+static bool is_valid_otp_range_raw(uint16_t starting_row, size_t raw_byte_count) {
+    if (starting_row >= NUM_OTP_ROWS) {
+        // Can only access from 0x000 .. (NUM_OTP_ROWS-1)
+        return false;
+    }
+    if (raw_byte_count % sizeof(uint32_t) != 0u) {
+        // Must be aligned to 4-byte boundaries
+        return false;
+    }
+    if (raw_byte_count > NUM_OTP_ROWS * sizeof(uint32_t)) {
+        // even if started at zero, this would be too large
+        // separate check to avoid overflows in later checks
+        return false;
+    }
+    // Above checks ensure this is safe to store in uint16_t
+    uint16_t row_count = raw_byte_count / sizeof(uint32_t);
+    if (row_count == 0u) {
+        return false;
+    }
+    if ((NUM_OTP_ROWS - row_count) < starting_row) {
+        // this would overflow past the last OTP row
+        return false;
+    }
+    // All checks passed.
+    return true;
+}
+
+static bool virt_initialize(uint64_t ignored_pages_mask) {
+    // Initialize the virtualized OTP pages
+    if (g_virtual_otp_initialized) {
+        PRINT_ERROR("OTP VIRT Error: Attempt to re-initialize already-virtualized OTP data\n");
+        return false;
+    }
+    memset(&g_virtual_otp, 0, sizeof(g_virtual_otp));
+    // read all 16k of OTP into the virtualized buffer
+    size_t error_count = 0u;
+    uint16_t page = 0;
+    for (; page < NUM_OTP_PAGES; ++page) {
+        uint64_t tst_mask = 1u;
+        tst_mask <<= page;
+        // skip values from this page if requested
+        if ((ignored_pages_mask & tst_mask) != 0u) {
+            // caller requested to ignored this page, so skip it
+            continue;
+        }
+        uint16_t row = page * NUM_OTP_PAGE_ROWS; // starting row for this page
+        for (uint16_t i = 0; i < NUM_OTP_PAGE_ROWS; ++i, ++row) {
+            if (!hw_read_raw_otp_wrapper(row, &g_virtual_otp.rows[row], sizeof(SAFEROTP_RAW_READ_RESULT))) {
+                // can easily scan for errors later by just checking if any of the high bits were set
+                g_virtual_otp.rows[row].as_uint32 = 0xFFFFFFFFu; // ensure the stored value is an error
+                error_count++;
+            }
         }
     }
+    if (error_count > 0u) {
+        PRINT_WARNING("OTP VIRT Warning: Failed to read %d rows of OTP data into virtualized buffer\n", error_count);
+        // loop and print failing indices?
+        for (uint16_t row = 0; row < 0x1000u; ++row) {
+            if ((g_virtual_otp.rows[row].as_uint32 & 0xFFu) != 0u){
+                PRINT_WARNING("OTP VIRT Warning: -->  Row 0x%03x (%02x:%02x) failed to read\n",
+                    row,
+                    (row / NUM_OTP_PAGE_ROWS), (row % NUM_OTP_PAGE_ROWS)
+                );
+            }
+        }
+    }
+    g_virtual_otp_initialized = true;
+    return true;
 }
-static inline uint16_t ROW_TO_OTP_PAGE(uint16_t row)    { return row >> 6; }
-#pragma error "TODO: Lots of things still to implement to enable virtualized OTP..."
+static bool virt_override_restore(uint16_t starting_row, const void* buffer, size_t buffer_size) {
+    // callers can then save/restore OTP state, such as from storage / file system
+    if (!is_valid_otp_range_raw(starting_row, buffer_size)) {
+        PRINT_ERROR("OTP VIRT Error: Invalid (start row / raw byte count): 0x%03x %zu\n", starting_row, buffer_size);
+        return false;
+    }
+    // NOTE: This simply replaces the values, even if doing so would not otherwise have been a valid write.
+    //       Allows resetting pages to zero (bits from 1 -> 0), bypasses permissions, etc.
+    memcpy(&g_virtual_otp.rows[starting_row], buffer, buffer_size);
+    return true;
+}
+static bool virt_override_save(uint16_t starting_row, void* buffer, size_t buffer_size) {
+    // callers can then save/restore OTP state, such as from storage / file system
+    if (!is_valid_otp_range_raw(starting_row, buffer_size)) {
+        PRINT_ERROR("OTP VIRT Error: Invalid (start row / raw byte count): 0x%03x %zu\n", starting_row, buffer_size);
+        return false;
+    }
+    memcpy(buffer, &g_virtual_otp.rows[starting_row], buffer_size);
+    return true;
+}
 
-#endif // defined(BP_USE_VIRTUALIZED_OTP)
+static bool virt_write_raw_otp_wrapper(uint16_t starting_row, const void* buffer, size_t buffer_size) {
+    if (!g_virtual_otp_initialized) {
+        PRINT_ERROR("OTP VIRT Error: Attempt to write virtualized OTP data without initialization\n");
+        return false;
+    }
+    // belt and suspenders ... even if caller did this
+    if (!is_valid_otp_range_raw(starting_row, buffer_size)) {
+        PRINT_ERROR("OTP VIRT WRITE Error: Invalid (start row / raw byte count): 0x%03x %zu\n", starting_row, buffer_size);
+        return false;
+    }
+    // TODO: Check BOOTLOCK7 to determine if bootrom will require ownership of BOOTLOCK2 (OTP)
+    size_t row_count = buffer_size / sizeof(uint32_t);
+    // process each row in order (per RP2350 datasheet ... )
+    for (size_t i = 0; i < row_count; ++i) {
+        // TODO: Any permissions checks, when implemented....
+
+        // verify the existing value was readable ... else refuse to modify it.
+        SAFEROTP_RAW_READ_RESULT *current = &g_virtual_otp.rows[starting_row + i];
+        if (current->is_error) {
+            PRINT_ERROR("OTP VIRT WRITE Error: Attempt to write virtualized OTP row 0x%03x, which previously failed to read (start row %03x, buffer size %zx)\n", starting_row+i, starting_row, buffer_size);
+            return false;
+        }
+        // OTP bits can only transition from zero to one (0 --> 1).
+        // Verify none of the bits would transition from (1 --> 0).
+        const SAFEROTP_RAW_READ_RESULT *new_value = (const SAFEROTP_RAW_READ_RESULT *)(  &(((const uint32_t*)buffer)[i]) );
+        if ((current->as_uint32 | new_value->as_uint32) != new_value->as_uint32) {
+            PRINT_ERROR("OTP VIRT WRITE Error: Attempt to write virtualized OTP row 0x%03x from %06x -> %06x, which would flip bits from 0 --> 1 (start row %03x, buffer size %zx)\n",
+                starting_row+i,
+                current->as_uint32, new_value->as_uint32,
+                starting_row, buffer_size
+            );
+            return false;
+        }
+        // Update the individual row's data
+        current->as_uint32 = new_value->as_uint32;
+    }
+    return true;
+}
+// returns TRUE on successful read, FALSE on failures
+static bool virt_read_raw_otp_wrapper(uint16_t starting_row, void* buffer, size_t buffer_size) {
+    if (!g_virtual_otp_initialized) {
+        PRINT_ERROR("OTP VIRT Error: Attempt to write virtualized OTP data without initialization\n");
+        return false;
+    }
+    // belt and suspenders ... even if caller did this
+    if (!is_valid_otp_range_raw(starting_row, buffer_size)) {
+        PRINT_ERROR("OTP VIRT READ Error: Invalid (start row / raw byte count): 0x%03x %zu\n", starting_row, buffer_size);
+        return false;
+    }
+    // TODO: Check BOOTLOCK7 to determine if bootrom will require ownership of BOOTLOCK2 (OTP)
+    size_t row_count = buffer_size / sizeof(uint32_t);
+    // process each row in order (per RP2350 datasheet ... )
+    for (size_t i = 0; i < row_count; ++i) {
+        // TODO: Any permissions checks, when implemented....
+
+        // verify the existing value was readable ... else return an error
+        SAFEROTP_RAW_READ_RESULT *current = &g_virtual_otp.rows[starting_row + i];
+        if (current->is_error) {
+            PRINT_ERROR("OTP VIRT READ Error: Attempt to write virtualized OTP row 0x%03x, which previously failed to read (start row %03x, buffer size %zx)\n", starting_row+i, starting_row, buffer_size);
+            return false; // report the error
+        }
+        // Else return the value from the virtualized buffer
+        uint32_t * to_write = &(((uint32_t*)buffer)[i]);
+        *to_write = current->as_uint32;
+    }
+    return true;
+}
+
+#pragma endregion // OTP HAL layer ... to allow for virtualized OTP
 
 // don't want to use that difficult-to-parse API in many places....
 static bool write_raw_wrapper(uint16_t starting_row, const void* buffer, size_t buffer_size) {
-    // TODO: if virtualized OTP:
-    //       * STRETCH GOAL: read and apply page permissions
-    //       * if not already virtualized data, read current data into overlay memory
-    //       * update overlay memory with new data
-    //       * write updated virtualized OTP data to flash (so it's loaded next boot)
-    //       Else, write to actual OTP fuses:
-    return hw_write_raw_otp_wrapper(starting_row, buffer, buffer_size);
+    if (!is_valid_otp_range_raw(starting_row, buffer_size)) {
+        PRINT_ERROR("OTP WRITE Error: Invalid (start row / raw byte count): 0x%03x %zu\n", starting_row, buffer_size);
+        return false;
+    }
+    if (g_virtual_otp_initialized) {
+        return virt_write_raw_otp_wrapper(starting_row, buffer, buffer_size);
+    } else {
+        return hw_write_raw_otp_wrapper(starting_row, buffer, buffer_size);
+    }
 }
 static bool read_raw_wrapper(uint16_t starting_row, void* buffer, size_t buffer_size) {
-    // TODO: if virtualized OTP:
-    //       * STRETCH GOAL: read and apply page permissions
-    //       * search for data in overlay memory
-    //       * if found in overlay, return the data from the overlay memory
-    //       * else, ...
-    //       else, read the data from the actual OTP fuses
-    return hw_read_raw_otp_wrapper(starting_row, buffer, buffer_size);
+    if (!is_valid_otp_range_raw(starting_row, buffer_size)) {
+        PRINT_ERROR("OTP WRITE Error: Invalid (start row / raw byte count): 0x%03x %zu\n", starting_row, buffer_size);
+        return false;
+    }
+    if (buffer_size % sizeof(uint32_t) != 0u) {
+        PRINT_ERROR("OTP VIRT Error: Attempt to read virtualized OTP data with non-aligned size %d\n", buffer_size);
+        return false;
+    }
+    if (g_virtual_otp_initialized) {
+        return virt_read_raw_otp_wrapper(starting_row, buffer, buffer_size);
+    } else {
+        return hw_read_raw_otp_wrapper(starting_row, buffer, buffer_size);
+    }
 }
 // RP2350 OTP storage is strongly recommended to use some form of
 // error correction.  Most rows will use ECC, but three other forms exist:
@@ -149,7 +341,7 @@ static bool write_single_otp_ecc_row(uint16_t row, uint16_t data) {
     // If so, try to write the data, even if some bits are already set!
 
     // 1. Read the existing raw data
-    SAFEROTP_RAW_READ_RESULT existing_raw_data;
+    uint32_t existing_raw_data;
     if (!read_raw_wrapper(row, &existing_raw_data, sizeof(existing_raw_data))) {
         PRINT_ERROR("OTP_RW Error: Failed to read OTP raw row %03x\n", row);
         return false;
@@ -158,7 +350,7 @@ static bool write_single_otp_ecc_row(uint16_t row, uint16_t data) {
     // 2. SUCCESS if existing raw data already encodes the value; Do not update the OTP row.
     //    TODO: Consider if existing data has a single bit flipped from one to zero ... could write
     //          the extra bit to try to reduce errors?
-    uint32_t decode_result = saferotp_decode_raw(existing_raw_data.as_uint32);
+    uint32_t decode_result = saferotp_decode_raw(existing_raw_data);
     if (((decode_result & 0xFF000000u) == 0u) && ((uint16_t)decode_result == data)) {
         // already written, nothing more to do for this row
         PRINT_VERBOSE("OTP_RW: Row %03x already has data 0x%04x .. not writing\n", row, data);
@@ -168,36 +360,57 @@ static bool write_single_otp_ecc_row(uint16_t row, uint16_t data) {
     // 3. Do we have to adjust the encoded data due to existing BRBP bits?  Determine data to write (or fail if not possible)
     uint32_t data_to_write;
     do {
-        SAFEROTP_RAW_READ_RESULT encoded_new_data      = { .as_uint32 = saferotp_calculate_ecc(data) };
-        SAFEROTP_RAW_READ_RESULT encoded_new_data_brbp = { .as_uint32 = encoded_new_data.as_uint32 ^ 0x00FFFFFFu };
-        
-        // count how many bits would be flipped vs. the new data
-        uint_fast8_t bits_to_flip      = __builtin_popcount(existing_raw_data.as_uint32 ^ encoded_new_data.as_uint32);
-        uint_fast8_t bits_to_flip_brbp = __builtin_popcount(existing_raw_data.as_uint32 ^ encoded_new_data_brbp.as_uint32);
+        enum {
+            MASK_BRBP_BITS     = 0xC00000u,
+            MASK_NON_BRBP_BITS = 0x3FFFFFu,
+            MASK_ALL_RAW_BITS  = 0xFFFFFFu,
+        };
 
-        if (bits_to_flip == 0u) {
+        uint32_t encoded_new_data = saferotp_calculate_ecc(data);
+        uint32_t encoded_new_data_brbp = encoded_new_data ^ MASK_ALL_RAW_BITS;
+
+        // 1. bits can only transition from 0 --> 1
+        uint32_t to_write      = existing_raw_data | encoded_new_data;
+        uint32_t to_write_brbp = existing_raw_data | encoded_new_data_brbp;
+
+        // 2. bits that differ from new_data represent errors
+        uint32_t error_bits      = encoded_new_data      ^ to_write;
+        uint32_t error_bits_brbp = encoded_new_data_brbp ^ to_write_brbp;
+
+        // 3. One or fewer errors for non-brbp?  If so, that's good enough.
+        if (__builtin_popcount(error_bits) == 0u) {
             // Great!  Can write without adjusting for existing data.
-            data_to_write = encoded_new_data.as_uint32;
-        } else if (bits_to_flip_brbp == 0u) {
-            // Great!  Can write without error by using BRBP bits.
-            PRINT_VERBOSE("OTP_RW Info: Writing ECC OTP row %03x with data 0x%04x: Using BRBP bits\n", row, data);
-            data_to_write = encoded_new_data_brbp.as_uint32;
-        } else if (bits_to_flip == 1u) {
-            // Can write, but will have an existing single-bit error in the data...
-            PRINT_WARNING("OTP_RW Warn: Writing ECC OTP row %03x with data 0x%04x: Redundancy compromised, but writing is possible with 1-bit error.\n",
-                row, data, encoded_new_data.as_uint32, existing_raw_data.as_uint32
-            );
-            data_to_write = encoded_new_data.as_uint32 | existing_raw_data.as_uint32;
-        } else if (bits_to_flip_brbp == 1u) {
-            // Can write, but will need to use BRBP bits, and there will still be a single-bit error in the data...
-            PRINT_WARNING("OTP_RW Warn: Writing ECC OTP row %03x with data 0x%04x: Redundancy compromised, but writing is possible with BRBP *AND* 1-bit error.\n",
-                row, data, encoded_new_data_brbp.as_uint32, existing_raw_data.as_uint32
-            );
-            data_to_write = encoded_new_data_brbp.as_uint32 | existing_raw_data.as_uint32;
+            data_to_write = to_write;
+        } else if (__builtin_popcount(error_bits_brbp) == 0u) {
+            // Great!  Can write without adjusting for existing data.
+            data_to_write = to_write_brbp;
+        } else if (
+            (__builtin_popcount(error_bits_brbp & MASK_BRBP_BITS    ) <= 1u) &&
+            (__builtin_popcount(error_bits_brbp & MASK_NON_BRBP_BITS) <= 1u)
+        ) {
+            // OPTION: Consider allowing callers to REJECT writes with even a single-bit error?
+            // BRBP can have a single-bit error, and the remaining bits can also have a single-bit error.
+            // The value will still be properly decoded.
+            PRINT_WARNING("OTP_RW WARN: Writing ECC OTP row %03x with data 0x%06x: Redundancy compromised, but writing as BRBP is possible (bit errors: %06x).\n",
+                row, encoded_new_data_brbp, error_bits_brbp
+            );  
+            data_to_write = to_write_brbp;
+        } else if (
+            (__builtin_popcount(error_bits & MASK_BRBP_BITS    ) <= 1u) &&
+            (__builtin_popcount(error_bits & MASK_NON_BRBP_BITS) <= 1u)
+        ) {
+            // OPTION: Consider allowing callers to REJECT writes with even a single-bit error?
+            // BRBP can have a single-bit error, and the remaining bits can also have a single-bit error.
+            // The value will still be properly decoded.
+            // TODO: Verify the bootrom will also allow non-BRBP data to have a single-bit error in the BRBP bits?
+            PRINT_WARNING("OTP_RW WARN: Writing ECC OTP row %03x with data 0x%06x: Redundancy compromised, but writing as BRBP is possible (bit errors: %06x).\n",
+                row, encoded_new_data, error_bits
+            );  
+            data_to_write = to_write;
         } else {
-            // No way to write the data without multiple bit errors
-            PRINT_ERROR("OTP_RW Error: Cannot write ECC OTP row %03x with data 0x%04x: Encoded 0x%06x / 0x%06x vs. Existing 0x%06x prevents writing\n",
-                row, data, encoded_new_data.as_uint32, encoded_new_data_brbp.as_uint32, existing_raw_data.as_uint32
+            // No way to write the encoded ECC data (even if using BRBP)
+            PRINT_ERROR("OTP_RW Error: Cannot write ECC OTP row %03x with data 0x%06x / 0x%06x (existing 0x%06x): bit errors %06x / %06x\n",
+                row, encoded_new_data, encoded_new_data_brbp, existing_raw_data, error_bits, error_bits_brbp
             );
             return false;
         }
@@ -206,7 +419,7 @@ static bool write_single_otp_ecc_row(uint16_t row, uint16_t data) {
     // 4. write the encoded raw data
     if (!write_raw_wrapper(row, &data_to_write, sizeof(data_to_write))) {
         PRINT_ERROR("OTP_RW Error: Failed to write ECC OTP row %03x with data 0x%06x (ECC encoding of 0x%04x)\n",
-            row, data, data_to_write, data_to_write
+            row, data_to_write, data
         );
         return false;
     }
@@ -260,11 +473,19 @@ static bool write_single_otp_raw_row(uint16_t row, uint32_t data) {
     return true;
 }
 static bool read_single_otp_value_N_of_M(uint16_t start_row, uint8_t N, uint8_t M, uint32_t* out_data) {
+    #define MAX_M_VALUE (8u)
+
     *out_data = 0xFFFFFFFFu;
 
+    static_assert(MAX_M_VALUE < UINT8_MAX, "MAX_M_VALUE must be less than 0xFFu else need to adjust variables currently using uint8_t and uint_fast8_t");
+
     // Support both RBIT3 and RBIT8
-    if (N == 2 && M == 3) { }
-    else if (N == 3 && M == 8) {}
+    if (M > MAX_M_VALUE) {
+        PRINT_ERROR("OTP_RW Error: Read OTP N-of-M: Unsupported M=%d (max %zu)\n", M, MAX_M_VALUE);
+        return false;
+    }
+    else if (N == 2 && M == 3) { }
+    else if (N == 3 && M == 8) { }
     else {
         // The below code ***should*** work for any N-of-M, so long as both N and M are <= 8.
         // However, it's not been tested, and is not used in any real-world scenario.
@@ -272,35 +493,27 @@ static bool read_single_otp_value_N_of_M(uint16_t start_row, uint8_t N, uint8_t 
         PRINT_ERROR("OTP_RW Error: Read OTP N-of-M: Unsupported N=%d, M=%d\n", N, M);
         return false;
     }
-    uint32_t v[8u] = {0u};    // zero-initialize the array, sized for maximum supported `M`
-    bool     r[8u] = {false}; // zero-initialized is false
-    assert(M <= 8u);
+    uint32_t v[MAX_M_VALUE] = {0u};    // zero-initialize the array, sized for maximum supported `M`
+    bool     r[MAX_M_VALUE] = {false}; // zero-initialized is false
+    uint_fast8_t votes[24]; // one count for each potential bit to be set
+    uint_fast8_t successful_reads = 0u;
+    uint_fast8_t failed_reads = 0u;
 
     // Read each of the `M` rows
+    // tracking total count of successful / failed reads
     for (size_t i = 0; i < M; ++i) {
-        r[i] = read_raw_wrapper(start_row+i, &(v[i]), sizeof(uint32_t));
-    }
-
-    // Ensure at least `N` reads were successful, else return an error
-    uint_fast8_t successful_reads = 0;
-    for (size_t i = 0; i < M; ++i) {
-        if (r[i]) {
+        bool tmp = read_raw_wrapper(start_row+i, &(v[i]), sizeof(uint32_t));
+        r[i] = tmp;
+        if (tmp) {
             ++successful_reads;
+        } else {
+            ++failed_reads;
         }
     }
-    if (successful_reads < N) {
-        PRINT_ERROR("OTP_RW Error: Read OTP N-of-M: rows 0x%03x to 0x%03x: only %d of %d reads successful ... failing\n", start_row, start_row+M-1, successful_reads, M);
-        return false;
-    }
 
-
-    uint_fast8_t votes[24]; // one count for each potential bit to be set
-
-    // Count the votes from the successful reads
+    // Calculate the votes from the reads that succeeded
     for (size_t i = 0; i < M; ++i) {
         // don't count any votes from failed reads
-        // Could actually skip this, IFF failed reads were set to zero.
-        // This is because the voting only considers bits set to one.
         if (!r[i]) {
             continue;
         }
@@ -314,21 +527,51 @@ static bool read_single_otp_value_N_of_M(uint16_t start_row, uint8_t N, uint8_t 
         }
     }
 
-    // Generate a result based on the votes (set if votes >= N)
+    // Success depends on BOTH the count of successful reads AND
+    // the count of failed reads.  This is to avoid a marginal OTP row
+    // that fails to read this time, but succeeds a later read,
+    // from causing the result to change.
+    //
+    // If fewer than N successful reads:
+    //    None of the votes can be sufficient to set any bits (ERROR)
+    if (successful_reads < N) {
+        PRINT_ERROR("OTP_RW Error: Read OTP N-of-M: rows 0x%03x to 0x%03x: only %d of %d reads successful ... failing\n", start_row, start_row+M-1, successful_reads, M);
+        return false;
+    }
+
+    // For each bit voted upon:
+    //    If the number of votes is >= M:
+    //       Set the bit in the result. (SUCCESS)
+    //       Failed reads are irrelevant to this result.
+    //    Else if the number of failed reads is >= (N - votes):
+    //       Votes say zero, but failed reads could make it 1.  (ERROR)
+    //    Else:
+    //       The votes say zero, which is true even if all the failed reads
+    //       would have added to the vote. (SUCCESS)
     uint32_t result = 0u;
     for (uint_fast8_t i = 0; i < 24u; ++i) {
         if (votes[i] >= N) {
-            result |= (1u << i);
+            uint32_t mask = (1u << i);
+            result |= mask;
+        } else if (failed_reads >= (N - votes[i])) {
+            // votes from successful reads say the bit is zero, but
+            // the failed reads could change the result from 0 --> 1
+            PRINT_ERROR("OTP_RW Error: rows 0x%03x to 0x%03x: failed reads %d >= %d - %d votes ... failing\n", start_row, start_row+M-1, failed_reads, N, votes[i]);
+            return false;
+        } else {
+            // votes from successful reads say the bit is zero, and
+            // even if all failed reads voted for a `1`, the votes
+            // would still say the bit is zero.
+            // this is a success ... leave the bit as zero in the result.
         }
     }
-    // return the voted-upon result
-    return false;
+    // SUCCESS -- return the voted-upon result
+    return true;
 }
 static bool write_single_otp_value_N_of_M(uint16_t start_row, uint8_t N, uint8_t M, uint32_t new_value) {
 
     // 1. read the old data
-    PRINT_DEBUG("OTP_RW Debug: Write OTP 2-of-3: row 0x%03x\n", start_row); WAIT_FOR_KEY();
-
+    PRINT_DEBUG("OTP_RW Debug: Write OTP 2-of-3: row 0x%03x\n", start_row);
     uint32_t old_voted_bits;
     if (!read_single_otp_value_N_of_M(start_row, N, M, &old_voted_bits)) {
         PRINT_DEBUG("OTP_RW Debug: Failed to read %d-of-%d starting at row 0x%03x\n", N, M, start_row);
@@ -363,7 +606,7 @@ static bool write_single_otp_value_N_of_M(uint16_t start_row, uint8_t N, uint8_t
         // new_value may have additional bits set that are not intended to be set after voting.
         // This is OK ... validate voted-upon results after the writes are all done.
         uint32_t to_write = old_data | new_value;
-        PRINT_DEBUG("OTP_RW Debug: updating row 0x%03x: 0x%06x --> 0x%06x\n", start_row+i, old_data, to_write); WAIT_FOR_KEY();
+        PRINT_DEBUG("OTP_RW Debug: updating row 0x%03x: 0x%06x --> 0x%06x\n", start_row+i, old_data, to_write);
         if (!write_raw_wrapper(start_row+i, &to_write, sizeof(to_write))){
             PRINT_ERROR("OTP_RW Error: Failed to write new bits for OTP %d-of-%d: row 0x%03x: 0x%06x --> 0x%06x\n", N, M, start_row+i, old_data, to_write);
             continue; // to next OTP row, if any
@@ -371,14 +614,14 @@ static bool write_single_otp_value_N_of_M(uint16_t start_row, uint8_t N, uint8_t
         PRINT_DEBUG("OTP_RW Debug: Wrote new bits for OTP %d-of-%d: row 0x%03x: 0x%06x --> 0x%06x\n", N, M, start_row+i, old_data, to_write);
     }
 
-    // 3. Verify the data was updated to the expected value
+    // 3. Read the new N of M voted-upon bits
     uint32_t new_voted_bits;
     if (!read_single_otp_value_N_of_M(start_row, N, M, &new_voted_bits)) {
         PRINT_ERROR("OTP_RW Error: Failed to read agreed-upon new bits for OTP %d-of-%d starting at row 0x%03x\n", N, M, start_row);
         return false;
     }
 
-    // 4. Verify the new data matches the requested value
+    // 4. Verify the new voted-upon bits match the requested value
     if (new_voted_bits != new_value) {
         PRINT_ERROR("OTP_RW Error: OTP %d-of-%d: starting at row 0x%03x: 0x%06x -> 0x%06x, but got 0x%06x\n",
             N, M, start_row,
@@ -424,7 +667,7 @@ static bool read_otp_byte_3x(uint16_t row, uint8_t* out_data) {
 }
 static bool write_otp_byte_3x(uint16_t row, uint8_t new_value) {
 
-    PRINT_DEBUG("OTP_RW Debug: Write OTP byte_3x: row 0x%03x\n", row); WAIT_FOR_KEY();
+    PRINT_DEBUG("OTP_RW Debug: Write OTP byte_3x: row 0x%03x\n", row);
 
     // 1. read the old data as raw bits
     SAFEROTP_RAW_READ_RESULT old_raw_data;
@@ -467,7 +710,7 @@ static bool write_otp_byte_3x(uint16_t row, uint8_t new_value) {
     to_write.as_bytes[0] |= new_value;
     to_write.as_bytes[1] |= new_value;
     to_write.as_bytes[2] |= new_value;
-    PRINT_DEBUG("OTP_RW Debug: Write OTP byte_3x: updating row 0x%03x: 0x%06x --> 0x%06x\n", row, old_raw_data.as_uint32, to_write.as_uint32); WAIT_FOR_KEY();
+    PRINT_DEBUG("OTP_RW Debug: Write OTP byte_3x: updating row 0x%03x: 0x%06x --> 0x%06x\n", row, old_raw_data.as_uint32, to_write.as_uint32);
     if (!write_raw_wrapper(row, &to_write, sizeof(to_write))) {
         PRINT_ERROR("OTP_RW Error: Failed to write new bits for byte_3x: row 0x%03x: 0x%06x --> 0x%06x\n", row, old_raw_data.as_uint32, to_write.as_uint32);
         return false;
@@ -491,40 +734,59 @@ static bool write_otp_byte_3x(uint16_t row, uint8_t new_value) {
 /// All code above this point are the static helper functions / implementation details.
 /// Only the below are the public API functions.
 
-bool saferotp_write_single_row_raw(uint16_t row, uint32_t new_value) {
+bool saferotp_virtualization_init_pages(uint64_t ignored_pages_mask) {
+    virt_initialize(ignored_pages_mask);
+    return true;
+}
+bool saferotp_virtualization_restore(uint16_t starting_row, const void* buffer, size_t buffer_size) {
+    return virt_override_restore(starting_row, buffer, buffer_size);
+}
+bool saferotp_virtualization_save(uint16_t starting_row, void* buffer, size_t buffer_size) {
+    return virt_override_save(starting_row, buffer, buffer_size);
+}
+
+// NOTE: On failure, the state of the OTP row(s) is UNDEFINED.
+//       For example, some rows may have been written, while other rows failed to be written.
+//       It's also possible that a single OTP row was partially written, and thus contains
+//       an invalid value.
+//       It is the caller's responsibility, upon a write failing, to perform any necessary
+//       data cleanup.  For example, callers might raw write 0xFFFFFFu to at least some
+//       of the rows, or otherwise mark the range as containing unreliable data.
+
+
+bool saferotp_write_single_value_raw_unsafe(uint16_t row, uint32_t new_value) {
     return write_single_otp_raw_row(row, new_value);
 }
-bool saferotp_read_single_row_raw(uint16_t row, uint32_t* out_data) {
+bool saferotp_read_single_value_raw_unsafe(uint16_t row, uint32_t* out_data) {
     return read_raw_wrapper(row, out_data, sizeof(uint32_t));
 }
-bool saferotp_write_single_row_ecc(uint16_t row, uint16_t new_value) {
+bool saferotp_write_single_value_ecc(uint16_t row, uint16_t new_value) {
     return write_single_otp_ecc_row(row, new_value);
 }
-bool saferotp_read_single_row_ecc(uint16_t row, uint16_t* out_data) {
+bool saferotp_read_single_value_ecc(uint16_t row, uint16_t* out_data) {
     return read_single_otp_ecc_row(row, out_data);
 }
-bool saferotp_write_single_row_redundant_byte3x(uint16_t row, uint8_t new_value) {
+bool saferotp_write_single_value_byte3x(uint16_t row, uint8_t new_value) {
     return write_otp_byte_3x(row, new_value);
 }
-bool saferotp_read_single_row_redundant_byte3x(uint16_t row, uint8_t* out_data) {
+bool saferotp_read_single_value_byte3x(uint16_t row, uint8_t* out_data) {
     return read_otp_byte_3x(row, out_data);
 }
-bool saferotp_write_redundant_rows_RBIT3(uint16_t start_row, uint32_t new_value) {
+bool saferotp_write_single_value_rbit3(uint16_t start_row, uint32_t new_value) {
     return write_single_otp_value_N_of_M(start_row, 2, 3, new_value);
 }
-bool saferotp_read_redundant_rows_RBIT3(uint16_t start_row, uint32_t* out_data) {
+bool saferotp_read_single_value_rbit3(uint16_t start_row, uint32_t* out_data) {
     return read_single_otp_value_N_of_M(start_row, 2, 3, out_data);
 }
-bool saferotp_write_redundant_rows_RBIT8(uint16_t start_row, uint32_t new_value) {
+bool saferotp_write_single_value_rbit8(uint16_t start_row, uint32_t new_value) {
     return write_single_otp_value_N_of_M(start_row, 3, 8, new_value);
 }
-bool saferotp_read_redundant_rows_RBIT8(uint16_t start_row, uint32_t* out_data) {
+bool saferotp_read_single_value_rbit8(uint16_t start_row, uint32_t* out_data) {
     return read_single_otp_value_N_of_M(start_row, 3, 8, out_data);
 }
 
-// Arbitrary buffer size support functions
-
-bool saferotp_write_ecc_data(uint16_t start_row, const void* data, size_t count_of_bytes) {
+// Arbitrary buffer size support functions ...
+bool saferotp_write_data_ecc(uint16_t start_row, const void* data, size_t count_of_bytes) {
 
     // write / verify one OTP row at a time
     size_t loop_count = count_of_bytes / 2u;
@@ -533,7 +795,7 @@ bool saferotp_write_ecc_data(uint16_t start_row, const void* data, size_t count_
     // Write full-sized rows first
     for (size_t i = 0; i < loop_count; ++i) {
         uint16_t tmp = ((const uint16_t*)data)[i];
-        if (!saferotp_write_single_row_ecc(start_row + i, tmp)) {
+        if (!saferotp_write_single_value_ecc(start_row + i, tmp)) {
             return false;
         }
     }
@@ -543,13 +805,13 @@ bool saferotp_write_ecc_data(uint16_t start_row, const void* data, size_t count_
         // Read the single byte ... do NOT read as uint16_t as additional byte may not be valid readable memory
         // and use the local stack uint16_t for the actual write operation.
         uint16_t tmp = ((const uint8_t*)data)[count_of_bytes-1];
-        if (!saferotp_write_single_row_ecc(start_row + loop_count, tmp)) {
+        if (!saferotp_write_single_value_ecc(start_row + loop_count, tmp)) {
             return false;
         }
     }
     return true;
 }
-bool saferotp_read_ecc_data(uint16_t start_row, void* out_data, size_t count_of_bytes) {
+bool saferotp_read_data_ecc(uint16_t start_row, void* out_data, size_t count_of_bytes) {
     if (count_of_bytes >= (0x1000*2)) { // OTP rows from 0x000u to 0xFFFu, so max 0x1000*2 bytes
         return false;
     }
@@ -561,7 +823,7 @@ bool saferotp_read_ecc_data(uint16_t start_row, void* out_data, size_t count_of_
     // Read full-sized rows first
     for (size_t i = 0; i < loop_count; ++i) {
         uint16_t * b = ((uint16_t*)out_data) + i; // pointer arithmetic
-        if (!saferotp_read_single_row_ecc(start_row + i, b)) {
+        if (!saferotp_read_single_value_ecc(start_row + i, b)) {
             return false;
         }
     }
@@ -569,7 +831,7 @@ bool saferotp_read_ecc_data(uint16_t start_row, void* out_data, size_t count_of_
     // Read any final partial-row data
     if (requires_buffering_last_row) {
         uint16_t tmp = 0xFFFFu;
-        if (!saferotp_read_single_row_ecc(start_row + loop_count, &tmp)) {
+        if (!saferotp_read_single_value_ecc(start_row + loop_count, &tmp)) {
             return false;
         }
         // update the last single byte of the buffer
@@ -580,7 +842,7 @@ bool saferotp_read_ecc_data(uint16_t start_row, void* out_data, size_t count_of_
     return true;
 }
 
-bool saferotp_read_raw_data(uint16_t start_row, void* out_data, size_t count_of_bytes) {
+bool saferotp_read_data_raw_unsafe(uint16_t start_row, void* out_data, size_t count_of_bytes) {
     if (count_of_bytes == 0u) {
         return false; // ?? should this return true?
     }
@@ -593,7 +855,7 @@ bool saferotp_read_raw_data(uint16_t start_row, void* out_data, size_t count_of_
     }
     return read_raw_wrapper(start_row, out_data, count_of_bytes);
 }
-bool saferotp_write_raw_data(uint16_t start_row, const void* data, size_t count_of_bytes) {
+bool saferotp_write_data_raw_unsafe(uint16_t start_row, const void* data, size_t count_of_bytes) {
     if (count_of_bytes == 0u) {
         return false; // ?? should this return true?
     }


### PR DESCRIPTION
Improved consistency in API naming.

Improved handling of `RBIT3`, `RBIT8` and `BYTE3X` encodings, especially in error conditions.
* Explicit explanation of failure conditions, including what occurs when some OTP rows are unreadable

Enable virtualized OTP
* Obviously, only applies when using this library's APIs...
* Currently just uses a static global 16k allocation (always allocated)
* Intent is to add a CMake option to enable / disable virtualization feature, so that memory cost isn't paid when it's not used.

Documentation updates